### PR TITLE
feat(git): add commit message normalizer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,14 @@ repos:
     rev: v0.11.0
     hooks:
       - id: yamlfmt
+  - repo: local
+    hooks:
+      - id: normalize-commit-msg
+        name: normalize commit message
+        entry: scripts/normalize-commit-msg.sh
+        language: script
+        stages: [prepare-commit-msg]
+        always_run: true
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.22.0
     hooks:

--- a/scripts/normalize-commit-msg.sh
+++ b/scripts/normalize-commit-msg.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+# normalize-commit-msg.sh — Normalize commit messages to Conventional Commits format
+# Usage: normalize-commit-msg.sh <commit-msg-file> [commit-source]
+#
+# Handles:
+#   - Emoji-prefixed messages -> maps to conventional type
+#   - Hybrid emoji+conventional -> strips emoji, keeps type
+#   - Already-valid conventional commits -> pass-through
+#   - Bare verb messages -> infers type from verb
+#   - Merge/fixup/amend/squash/revert commits -> pass-through
+#   - Warns if subject line > 72 chars
+#
+# Install as a prepare-commit-msg hook via pre-commit framework.
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="${1:?Usage: normalize-commit-msg.sh <commit-msg-file>}"
+COMMIT_SOURCE="${2:-}"
+
+if [ ! -f "$COMMIT_MSG_FILE" ]; then
+    echo "Error: commit message file not found: $COMMIT_MSG_FILE" >&2
+    exit 1
+fi
+
+# Skip normalization for message/template/merge/squash sources
+if [[ "$COMMIT_SOURCE" == "merge" || "$COMMIT_SOURCE" == "squash" ]]; then
+    exit 0
+fi
+
+# Read first non-comment, non-empty line as the subject
+subject=""
+while IFS= read -r line; do
+    [[ "$line" =~ ^# ]] && continue
+    [[ -z "${line// /}" ]] && continue
+    subject="$line"
+    break
+done < "$COMMIT_MSG_FILE"
+
+# Empty message — let git handle it
+if [ -z "$subject" ]; then
+    exit 0
+fi
+
+# Pass-through: merge commits, fixup, squash, amend, revert
+if [[ "$subject" =~ ^(Merge\ |fixup!\ |squash!\ |amend!\ |Revert\ ) ]]; then
+    exit 0
+fi
+
+# Check if subject is already a valid conventional commit
+is_conventional() {
+    [[ "$1" =~ ^[a-z]+(\([a-zA-Z0-9_/-]+\))?!?:\ .+ ]]
+}
+
+# Map verb to conventional type
+verb_to_type() {
+    case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+        add | create | implement | introduce) echo "feat" ;;
+        fix | repair | patch | resolve | correct) echo "fix" ;;
+        update | change | modify | adjust | tweak | improve | enhance) echo "feat" ;;
+        remove | delete | drop | clean | cleanup) echo "chore" ;;
+        refactor | reorganize | restructure | simplify | extract | move | rename) echo "refactor" ;;
+        document | docs) echo "docs" ;;
+        test | spec) echo "test" ;;
+        configure | config | setup | install | bump | upgrade) echo "chore" ;;
+        optimize | speed | perf) echo "perf" ;;
+        deploy | release | publish) echo "chore" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Replace subject line in commit message file, preserving body
+replace_subject() {
+    local new_subject="$1"
+    local tmpfile
+    tmpfile=$(mktemp)
+    local replaced=0
+    while IFS= read -r line; do
+        if [ $replaced -eq 0 ] && [[ ! "$line" =~ ^# ]] && [ -n "${line// /}" ]; then
+            echo "$new_subject" >> "$tmpfile"
+            replaced=1
+        else
+            echo "$line" >> "$tmpfile"
+        fi
+    done < "$COMMIT_MSG_FILE"
+    mv "$tmpfile" "$COMMIT_MSG_FILE"
+}
+
+# Warn if subject exceeds max length
+warn_length() {
+    local msg="$1"
+    if [ ${#msg} -gt 72 ]; then
+        echo "Warning: subject line is ${#msg} chars (max 72): $msg" >&2
+    fi
+}
+
+# Lowercase the first character of a string
+lc_first() {
+    local str="$1"
+    if [ -z "$str" ]; then
+        echo ""
+        return
+    fi
+    echo "$(echo "${str:0:1}" | tr '[:upper:]' '[:lower:]')${str:1}"
+}
+
+# --- Emoji detection via hex encoding ---
+detect_emoji_type() {
+    local text="$1"
+    local hex
+    hex=$(printf '%s' "$text" | LC_ALL=C od -An -tx1 | tr -d ' \n')
+
+    local emoji_type=""
+    local skip_bytes=0
+
+    # 4-byte emoji patterns (f0 9f xx xx)
+    case "${hex:0:8}" in
+        f09f8c9f) emoji_type="feat"; skip_bytes=4 ;;     # star2
+        f09f8e89) emoji_type="feat"; skip_bytes=4 ;;     # tada
+        f09f909b) emoji_type="fix"; skip_bytes=4 ;;      # bug
+        f09f9a91) emoji_type="fix"; skip_bytes=4 ;;      # ambulance
+        f09f939d) emoji_type="docs"; skip_bytes=4 ;;     # memo
+        f09f9396) emoji_type="docs"; skip_bytes=4 ;;     # book
+        f09f8ea8) emoji_type="refactor"; skip_bytes=4 ;; # art
+        f09f94a8) emoji_type="refactor"; skip_bytes=4 ;; # hammer
+        f09f94a7) emoji_type="chore"; skip_bytes=4 ;;    # wrench
+        f09f93a6) emoji_type="chore"; skip_bytes=4 ;;    # package
+        f09f91b7) emoji_type="ci"; skip_bytes=4 ;;       # construction_worker
+        f09f929a) emoji_type="ci"; skip_bytes=4 ;;       # green_heart
+        f09fa7aa) emoji_type="test"; skip_bytes=4 ;;     # test_tube
+        f09f9a80) emoji_type="perf"; skip_bytes=4 ;;     # rocket
+        f09f94a5) emoji_type="chore"; skip_bytes=4 ;;    # fire
+        f09fa496) emoji_type="feat"; skip_bytes=4 ;;     # robot
+        f09f9492) emoji_type="fix"; skip_bytes=4 ;;      # lock
+        f09f9aa7) emoji_type="wip"; skip_bytes=4 ;;      # construction
+        f09f9284) emoji_type="refactor"; skip_bytes=4 ;; # lipstick
+        f09f8f97) emoji_type="chore"; skip_bytes=4 ;;    # building_construction
+    esac
+
+    # 3-byte emoji patterns (e2 xx xx / ef xx xx)
+    if [ -z "$emoji_type" ]; then
+        case "${hex:0:6}" in
+            e29ca8) emoji_type="feat"; skip_bytes=3 ;;     # sparkles
+            e29c8f) emoji_type="docs"; skip_bytes=3 ;;     # pencil
+            e299bb) emoji_type="refactor"; skip_bytes=3 ;; # recycle
+            e29a99) emoji_type="chore"; skip_bytes=3 ;;    # gear
+            e29c85) emoji_type="test"; skip_bytes=3 ;;     # white_check_mark
+            e29aa1) emoji_type="perf"; skip_bytes=3 ;;     # zap
+            e2ac86) emoji_type="chore"; skip_bytes=3 ;;    # arrow_up
+        esac
+    fi
+
+    if [ -z "$emoji_type" ]; then
+        echo ""
+        return
+    fi
+
+    # Skip emoji bytes + optional fe0f variation selector (ef b8 8f = 3 bytes)
+    local rest_hex="${hex:$((skip_bytes * 2))}"
+    if [[ "$rest_hex" == efb88f* ]]; then
+        rest_hex="${rest_hex:6}"
+    fi
+    # Strip leading spaces (20 = space)
+    while [[ "$rest_hex" == 20* ]]; do
+        rest_hex="${rest_hex:2}"
+    done
+
+    # Convert remaining hex back to text
+    local rest_text=""
+    if [ -n "$rest_hex" ]; then
+        rest_text=$(printf "$(echo "$rest_hex" | sed 's/\(..\)/\\x\1/g')")
+    fi
+
+    echo "${emoji_type}|${rest_text}"
+}
+
+# --- Main normalization logic ---
+
+# 1. Already valid conventional commit — pass through
+if is_conventional "$subject"; then
+    warn_length "$subject"
+    exit 0
+fi
+
+# 2. Try emoji detection
+emoji_result=$(detect_emoji_type "$subject")
+
+if [ -n "$emoji_result" ]; then
+    detected_type="${emoji_result%%|*}"
+    rest="${emoji_result#*|}"
+
+    # 3. Hybrid: emoji + already-conventional text — strip emoji, keep conventional
+    if [ -n "$rest" ] && is_conventional "$rest"; then
+        replace_subject "$rest"
+        warn_length "$rest"
+        exit 0
+    fi
+
+    # Build conventional format from emoji type + remaining text
+    if [ -n "$rest" ]; then
+        rest=$(lc_first "$rest")
+        new_subject="${detected_type}: ${rest}"
+        replace_subject "$new_subject"
+        warn_length "$new_subject"
+        exit 0
+    fi
+fi
+
+# 4. No emoji — try verb inference
+first_word=$(echo "$subject" | awk '{print $1}')
+detected_type=$(verb_to_type "$first_word")
+
+if [ -n "$detected_type" ]; then
+    # Lowercase the description start after the type prefix
+    desc=$(lc_first "$subject")
+    new_subject="${detected_type}: ${desc}"
+    replace_subject "$new_subject"
+    warn_length "$new_subject"
+    exit 0
+fi
+
+# 5. No mapping found — leave as-is, just validate length
+warn_length "$subject"
+exit 0

--- a/scripts/test-normalize-commit-msg.sh
+++ b/scripts/test-normalize-commit-msg.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# test-normalize-commit-msg.sh — Tests for normalize-commit-msg.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NORMALIZE="$SCRIPT_DIR/normalize-commit-msg.sh"
+TMPDIR_BASE=$(mktemp -d)
+PASS=0
+FAIL=0
+
+cleanup() {
+    rm -rf "$TMPDIR_BASE"
+}
+trap cleanup EXIT
+
+# Run a single test case
+# Usage: run_test "test name" "input message" "expected first line"
+run_test() {
+    local name="$1"
+    local input="$2"
+    local expected="$3"
+
+    local tmpfile="$TMPDIR_BASE/msg_$$_$PASS$FAIL"
+    printf '%s\n' "$input" > "$tmpfile"
+
+    local stderr_file="$TMPDIR_BASE/stderr_$$_$PASS$FAIL"
+    "$NORMALIZE" "$tmpfile" 2>"$stderr_file" || true
+
+    local actual
+    actual=$(head -1 "$tmpfile")
+
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name"
+        echo "    input:    $input"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Run a test that checks stderr contains a warning
+run_test_warning() {
+    local name="$1"
+    local input="$2"
+    local expected_pattern="$3"
+
+    local tmpfile="$TMPDIR_BASE/msg_warn_$$_$PASS$FAIL"
+    printf '%s\n' "$input" > "$tmpfile"
+
+    local stderr_file="$TMPDIR_BASE/stderr_warn_$$_$PASS$FAIL"
+    "$NORMALIZE" "$tmpfile" 2>"$stderr_file" || true
+
+    if grep -q "$expected_pattern" "$stderr_file"; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name"
+        echo "    expected stderr to contain: $expected_pattern"
+        echo "    actual stderr: $(cat "$stderr_file")"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Commit Message Normalizer Tests ==="
+echo ""
+
+# --- Pass-through tests ---
+echo "-- Pass-through (already valid) --"
+
+run_test "valid conventional: feat" \
+    "feat: add user authentication" \
+    "feat: add user authentication"
+
+run_test "valid conventional: fix with scope" \
+    "fix(api): resolve null pointer in handler" \
+    "fix(api): resolve null pointer in handler"
+
+run_test "valid conventional: breaking change" \
+    "feat!: remove deprecated endpoints" \
+    "feat!: remove deprecated endpoints"
+
+run_test "valid conventional: chore" \
+    "chore: bump dependencies" \
+    "chore: bump dependencies"
+
+run_test "merge commit pass-through" \
+    "Merge branch 'feature/foo' into main" \
+    "Merge branch 'feature/foo' into main"
+
+run_test "fixup commit pass-through" \
+    "fixup! feat: add user auth" \
+    "fixup! feat: add user auth"
+
+run_test "squash commit pass-through" \
+    "squash! fix(api): patch handler" \
+    "squash! fix(api): patch handler"
+
+run_test "revert commit pass-through" \
+    "Revert \"feat: add user auth\"" \
+    "Revert \"feat: add user auth\""
+
+run_test "amend commit pass-through" \
+    "amend! fix: typo in handler" \
+    "amend! fix: typo in handler"
+
+echo ""
+
+# --- Emoji mapping tests ---
+echo "-- Emoji to conventional type --"
+
+run_test "sparkles -> feat" \
+    $'\xe2\x9c\xa8 Add user authentication' \
+    "feat: add user authentication"
+
+run_test "bug -> fix" \
+    $'\xf0\x9f\x90\x9b Fix null pointer in handler' \
+    "fix: fix null pointer in handler"
+
+run_test "memo -> docs" \
+    $'\xf0\x9f\x93\x9d Update README with examples' \
+    "docs: update README with examples"
+
+run_test "wrench -> chore" \
+    $'\xf0\x9f\x94\xa7 Configure CI pipeline' \
+    "chore: configure CI pipeline"
+
+run_test "recycle -> refactor" \
+    $'\xe2\x99\xbb Extract validation logic' \
+    "refactor: extract validation logic"
+
+run_test "zap -> perf" \
+    $'\xe2\x9a\xa1 Optimize database queries' \
+    "perf: optimize database queries"
+
+run_test "robot -> feat" \
+    $'\xf0\x9f\xa4\x96 Create expense-analyzer agent' \
+    "feat: create expense-analyzer agent"
+
+run_test "test_tube -> test" \
+    $'\xf0\x9f\xa7\xaa Add integration tests' \
+    "test: add integration tests"
+
+run_test "rocket -> perf" \
+    $'\xf0\x9f\x9a\x80 Improve startup time' \
+    "perf: improve startup time"
+
+run_test "lock -> fix" \
+    $'\xf0\x9f\x94\x92 Fix authentication bypass' \
+    "fix: fix authentication bypass"
+
+run_test "fire -> chore" \
+    $'\xf0\x9f\x94\xa5 Remove deprecated code' \
+    "chore: remove deprecated code"
+
+run_test "tada -> feat" \
+    $'\xf0\x9f\x8e\x89 Initial release' \
+    "feat: initial release"
+
+run_test "package -> chore" \
+    $'\xf0\x9f\x93\xa6 Update dependencies' \
+    "chore: update dependencies"
+
+run_test "art -> refactor" \
+    $'\xf0\x9f\x8e\xa8 Improve code formatting' \
+    "refactor: improve code formatting"
+
+run_test "construction_worker -> ci" \
+    $'\xf0\x9f\x91\xb7 Set up GitHub Actions' \
+    "ci: set up GitHub Actions"
+
+run_test "green_heart -> ci" \
+    $'\xf0\x9f\x92\x9a Fix CI build' \
+    "ci: fix CI build"
+
+echo ""
+
+# --- Hybrid format tests ---
+echo "-- Hybrid emoji + conventional --"
+
+run_test "emoji + conventional passes through stripped" \
+    $'\xe2\x9c\xa8 feat(api): add new endpoint' \
+    "feat(api): add new endpoint"
+
+run_test "emoji + conventional fix" \
+    $'\xf0\x9f\x90\x9b fix: resolve crash on startup' \
+    "fix: resolve crash on startup"
+
+run_test "emoji + conventional with scope" \
+    $'\xf0\x9f\x94\xa7 chore(deps): bump lodash' \
+    "chore(deps): bump lodash"
+
+echo ""
+
+# --- Verb inference tests ---
+echo "-- Verb to type inference --"
+
+run_test "Add -> feat" \
+    "Add user authentication" \
+    "feat: add user authentication"
+
+run_test "Fix -> fix" \
+    "Fix null pointer in handler" \
+    "fix: fix null pointer in handler"
+
+run_test "Update -> feat" \
+    "Update README with new examples" \
+    "feat: update README with new examples"
+
+run_test "Remove -> chore" \
+    "Remove deprecated endpoints" \
+    "chore: remove deprecated endpoints"
+
+run_test "Refactor -> refactor" \
+    "Refactor validation logic into module" \
+    "refactor: refactor validation logic into module"
+
+run_test "Configure -> chore" \
+    "Configure eslint for project" \
+    "chore: configure eslint for project"
+
+run_test "Optimize -> perf" \
+    "Optimize database query performance" \
+    "perf: optimize database query performance"
+
+run_test "Document -> docs" \
+    "Document API usage patterns" \
+    "docs: document API usage patterns"
+
+run_test "Create -> feat" \
+    "Create user profile page" \
+    "feat: create user profile page"
+
+run_test "Implement -> feat" \
+    "Implement OAuth2 flow" \
+    "feat: implement OAuth2 flow"
+
+run_test "Resolve -> fix" \
+    "Resolve race condition in worker" \
+    "fix: resolve race condition in worker"
+
+run_test "Delete -> chore" \
+    "Delete unused helper functions" \
+    "chore: delete unused helper functions"
+
+run_test "Extract -> refactor" \
+    "Extract shared logic into utils" \
+    "refactor: extract shared logic into utils"
+
+echo ""
+
+# --- Length validation tests ---
+echo "-- Length validation --"
+
+run_test_warning "warns on long subject" \
+    "feat: this is a very long commit message that definitely exceeds the seventy two character limit for subject lines" \
+    "Warning: subject line is"
+
+run_test_warning "warns on long normalized subject" \
+    "Add a very long feature description that definitely exceeds the seventy two character limit for commit messages" \
+    "Warning: subject line is"
+
+echo ""
+
+# --- Edge cases ---
+echo "-- Edge cases --"
+
+run_test "empty message (no crash)" \
+    "" \
+    ""
+
+run_test "comment-only message" \
+    "# This is a comment" \
+    "# This is a comment"
+
+run_test "unrecognized verb left as-is" \
+    "Yolo some random change" \
+    "Yolo some random change"
+
+run_test "message with body preserved" \
+    "feat: add auth
+This adds OAuth2 authentication" \
+    "feat: add auth"
+
+echo ""
+
+# --- Summary ---
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ $FAIL -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/normalize-commit-msg.sh` — a prepare-commit-msg hook that auto-converts emoji prefixes (sparkles->feat, bug->fix, memo->docs, recycle->refactor, wrench->chore, zap->perf, test_tube->test, etc.) and verb shortcuts (Add->feat, Fix->fix, Remove->chore, Refactor->refactor, etc.) to Conventional Commits format
- Add prepare-commit-msg hook entry to `.pre-commit-config.yaml` so normalization runs before commit-msg validation
- Lowercases description start for consistent formatting
- Passes through merge/fixup/squash/amend/revert commits untouched

## Test plan
- [x] 47 test cases in `scripts/test-normalize-commit-msg.sh` all pass
- [x] Covers: emoji mappings, verb inference, hybrid emoji+conventional, pass-through, edge cases (empty, comments, unrecognized verbs), length warnings

Nightshift-Task: commit-normalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
score: 0.3
cost-tier: Low (10-50k)
iterations: 1
duration: 8m58s
run-started: 2026-04-09T02:00:04-04:00
nightshift:metadata -->
