### PR TITLE
feat(git): wire up commit-normalize hook via .githooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,13 @@
+#!/bin/bash
+# commit-msg hook — normalizes commit messages to Conventional Commits format
+# Delegates to commit-normalize.sh in the repo's dotfiles/config/git/ directory.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+NORMALIZE_SCRIPT="$REPO_ROOT/dotfiles/config/git/commit-normalize.sh"
+
+if [ -x "$NORMALIZE_SCRIPT" ]; then
+    exec "$NORMALIZE_SCRIPT" "$1"
+else
+    echo "Warning: commit-normalize.sh not found at $NORMALIZE_SCRIPT — skipping normalization" >&2
+    exit 0
+fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,14 @@ repos:
     rev: v0.11.0
     hooks:
       - id: yamlfmt
+  - repo: local
+    hooks:
+      - id: commit-normalize
+        name: normalize commit message
+        entry: dotfiles/config/git/commit-normalize.sh
+        language: script
+        stages: [commit-msg]
+        always_run: true
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.22.0
     hooks:


### PR DESCRIPTION
## Summary

- The commit message normalizer (`dotfiles/config/git/commit-normalize.sh`) and test suite (`test/test-commit-normalize.sh`) were already on main but had no hook wiring — `core.hooksPath` pointed to `.githooks/` which didn't exist
- Creates `.githooks/commit-msg` hook that delegates to the normalizer script
- Adds `commit-normalize` as a local hook in `.pre-commit-config.yaml` for CI validation

## What the normalizer does

- Converts emoji-prefixed messages to conventional types (e.g., `✨ Add feature` → `feat: Add feature`)
- Infers types from verbs (e.g., `Fix bug` → `fix: Fix bug`)
- Strips emoji from hybrid formats (e.g., `🐛 fix: resolve crash` → `fix: resolve crash`)
- Passes through merge/fixup/squash/amend/revert commits unchanged
- Warns when subject line exceeds 72 characters

## Test plan

- [x] All 41 tests pass (`bash test/test-commit-normalize.sh`)
- [x] `.githooks/commit-msg` hook tested directly with emoji and verb messages
- [x] Pre-commit integration validated with `pre-commit run commit-normalize --hook-stage commit-msg`
- [x] YAML syntax validated

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: claude
score: 0.1
cost-tier: Low (10-50k)
iterations: 2
duration: 12m2s
run-started: 2026-04-11T02:00:06-04:00
nightshift:metadata -->
