### PR TITLE
Harden skill workflow gates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,10 +1,14 @@
 name: Auto-merge
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 jobs:
   auto-merge:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Enable auto-merge
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   auto-merge:
     name: Auto-merge
-    needs: [lint, shell-syntax, secrets]
-    if: github.event_name == 'pull_request'
+    needs: [lint, shell-syntax, stow-dry-run, install-dry-run, secrets]
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,19 @@ repos:
       - id: yamlfmt
   - repo: local
     hooks:
+      - id: skill-suite-lint
+        name: validate skill suite hardening gates
+        entry: dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills
+        language: script
+        pass_filenames: false
+      - id: skill-ref-lint
+        name: validate skill cross-references
+        entry: dotfiles/.claude/skills/lint-skill-refs.sh dotfiles/.claude/skills
+        language: script
+        pass_filenames: false
       - id: commit-normalize
         name: normalize commit message
-        entry: dotfiles/config/git/commit-normalize.sh
+        entry: dotfiles/.config/git/commit-normalize.sh
         language: script
         stages: [commit-msg]
         always_run: true

--- a/docs/executions/.pr-bodies/2026-06-15-pr-60.md
+++ b/docs/executions/.pr-bodies/2026-06-15-pr-60.md
@@ -11,6 +11,7 @@ Issue-only maintenance PR; no plan or phase-run artifact was used.
 - Adds pre-commit coverage for skill-suite invariants and skill cross-references. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-1c6f3fa5)
 - Adds a skill-suite linter for frontmatter, workflow ledgers, contracts, deprecated invocation flags, and optional runtime exposure checks. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e36082fc)
 - Adds a dry-run-first Codex runtime sync helper with explicit prune preview support. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-9af28111)
+- Skips auto-merge on draft PRs and waits for the full CI validation set before enabling auto-merge. [CI diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e978df92) [auto-merge diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-ce0c953f)
 
 ## How I implemented it
 
@@ -21,6 +22,8 @@ The workflow skills now expose `WORKFLOW_STEPS` ledgers where missing, and downs
 ## Deviations from the plan
 
 No formal plan artifact was created. One implementation adjustment was made during the audit loop: `sync-codex-skills.sh --prune` now previews prune candidates without `--apply`, instead of requiring an apply-mode destructive operation to inspect what would be removed.
+
+A second adjustment came from live CI evidence: the auto-merge job failed because the PR was intentionally opened as a draft. The workflows now skip auto-merge for draft PRs and retry auto-merge on `ready_for_review`.
 
 ## How to verify
 

--- a/docs/executions/.pr-bodies/2026-06-15-pr-60.md
+++ b/docs/executions/.pr-bodies/2026-06-15-pr-60.md
@@ -1,0 +1,47 @@
+## What this PR does
+
+Hardens the local skill and workflow suite around three failure modes found during the audit: branch-base assumptions, missing workflow progress ledgers, and drift between source skills and the Codex runtime. It adds enforceable lint hooks, a shared workflow base-branch policy, and a dry-run-first runtime sync/prune helper.
+
+## Phases completed
+
+Issue-only maintenance PR; no plan or phase-run artifact was used.
+
+## User-facing changes
+
+- Adds pre-commit coverage for skill-suite invariants and skill cross-references. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-1c6f3fa5)
+- Adds a skill-suite linter for frontmatter, workflow ledgers, contracts, deprecated invocation flags, and optional runtime exposure checks. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e36082fc)
+- Adds a dry-run-first Codex runtime sync helper with explicit prune preview support. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-9af28111)
+
+## How I implemented it
+
+The main behavior change is a shared base-branch policy that resolves `origin/staging` when present and falls back to the remote default branch only with an explicit `WORKFLOW_BASE_GATE`. `setup-worktree`, `workflow-router`, `workflow-build-one`, `run-backlog`, `execute-prd`, `execute-phase`, `workflow-review`, and `workflow-finalize` now consume that policy instead of hard-coding `origin/staging`. [policy diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e13202af)
+
+The workflow skills now expose `WORKFLOW_STEPS` ledgers where missing, and downstream prompt/issue skills require `WORKFLOW_BASE_GATE` plus the appropriate worktree gate in generated execution briefs. Contract fields were normalized into separate `Consumes`, `Produces`, `Requires`, `Side effects`, and `Human gates` lines so they can be linted reliably. [router diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-5ae94cbf) [review diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-fd4e6015) [backlog diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-4aeac68c)
+
+## Deviations from the plan
+
+No formal plan artifact was created. One implementation adjustment was made during the audit loop: `sync-codex-skills.sh --prune` now previews prune candidates without `--apply`, instead of requiring an apply-mode destructive operation to inspect what would be removed.
+
+## How to verify
+
+- `dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills`
+- `dotfiles/.claude/skills/lint-skill-refs.sh dotfiles/.claude/skills`
+- `bash -n dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills/sync-codex-skills.sh`
+- `shellcheck dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills/sync-codex-skills.sh`
+- `dotfiles/.claude/skills/sync-codex-skills.sh --prune`
+- `git diff --check`
+- `pre-commit run --all-files`
+
+Runtime note: `CHECK_CODEX_RUNTIME=1 dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills` currently reports 40 live runtime skills that are absent from active source or marked `codex-compatible:false`. This PR exposes the mismatch and provides a non-destructive prune preview, but does not prune the user's live runtime.
+
+## Issues
+
+No GitHub issue was linked to this maintenance pass.
+
+## Changelog entry
+
+chore(skills): harden workflow gates and Codex skill sync checks
+
+## References
+
+- `describe_pr: body_file=docs/executions/.pr-bodies/2026-06-15-pr-60.md; mode=issue_only; issues=none; phase_evidence=not_applicable; graphify=not_available_with_reason; applied_to_pr=true`

--- a/dotfiles/.claude/skills/analysis-council/SKILL.md
+++ b/dotfiles/.claude/skills/analysis-council/SKILL.md
@@ -11,6 +11,14 @@ Run a multi-lens council on an analytical topic — each persona a fresh subagen
 
 **Mechanics:** follow `council-scaffolding` for the full dispatch contract (roster resolution, rounds, synthesis, post-process, persist, report). Only the deltas below are council-specific.
 
+## Contract
+
+Consumes: analysis, claim, judgment call, or user-provided analytical context
+Produces: multi-lens council synthesis with disagreement, falsifiers, confidence, and per-expert reads
+Requires: independent expert contexts; graph context optional
+Side effects: may persist synthesis to `.council/analysis/` when the run reaches the persistence step
+Human gates: high-stakes or unresolved decision points are surfaced for human judgment; verification mode may halt on unverified claims
+
 ## When to invoke
 
 "Challenge my thinking on X", "what am I missing", "pressure-test this", "is this analysis right", "second opinion", "what would a skeptic say". Routing tiebreakers: single-claim fast check → `--fast`; polish a memo → `strategic-analysis-review` (not a council); build an analysis → `analysis-design` then loop back.

--- a/dotfiles/.claude/skills/clarity-review/SKILL.md
+++ b/dotfiles/.claude/skills/clarity-review/SKILL.md
@@ -22,6 +22,14 @@ The core idea: communication is expensive for the *reader*, and the writer shoul
 
 **Mechanics:** follow `review-scaffolding` for the review discipline, severity vocabulary, and report contract. The criteria, unit of analysis, and deltas below are what make this a *clarity* review.
 
+## Contract
+
+Consumes: document, email, Slack post, memo, metrics update, spec, instructions, or pasted draft
+Produces: structured clarity review with findings, severity, rationale, and concrete rewrites
+Requires: none; review-scaffolding guidance is used when available
+Side effects: none unless the user explicitly asks to edit a file
+Human gates: unclear audience/purpose may require an assumption or clarification before high-stakes rewrites
+
 ## Criteria — the standards
 
 Apply the 5 C's to everything; the metrics rules when the document reports numbers; the structural checks to longer docs, specs, and instructions.

--- a/dotfiles/.claude/skills/deprecated/right-sized-prs/SKILL.md
+++ b/dotfiles/.claude/skills/deprecated/right-sized-prs/SKILL.md
@@ -11,6 +11,14 @@ Status: deprecated as a skill. Policy extracted to ~/.claude/docs/pr-sizing-poli
 - Replaced by: ~/.claude/docs/pr-sizing-policy.md
 - Date: 2026-06-10
 
+## Contract
+
+Consumes: PR sizing question, implementation slice, or reviewable diff scope
+Produces: sizing guidance, split proposal shape, and size exception criteria
+Requires: none
+Side effects: none
+Human gates: oversized or scope-changing split decisions require human approval through the owning workflow
+
 ---
 
 # Right-Sized PRs

--- a/dotfiles/.claude/skills/describe-pr/SKILL.md
+++ b/dotfiles/.claude/skills/describe-pr/SKILL.md
@@ -22,6 +22,14 @@ Standalone use is **deprecated**; this remains loadable only because `workflow-f
 
 Edge cases, the issue-discovery source list, worked examples, and tuning notes live in `references/details.md` — load it when needed.
 
+## Contract
+
+Consumes: branch diff, git log, issue/PR metadata, optional plan, phase-run, post-mortem, and graph context
+Produces: PR body file under `docs/executions/.pr-bodies/` and `describe_pr` evidence line
+Requires: git; `gh` when applying to or discovering an existing PR
+Side effects: writes PR body file; may update PR body only when `apply=true`
+Human gates: missing required phase evidence, missing reviewer validation steps, or ambiguous issue disposition halts for human input
+
 ## Required describe_pr evidence line
 
 Every successful run emits one line for `workflow-finalize`:

--- a/dotfiles/.claude/skills/execute-phase/SKILL.md
+++ b/dotfiles/.claude/skills/execute-phase/SKILL.md
@@ -25,7 +25,7 @@ inputs:
   - name: auto_proceed
     type: boolean
     default: true
-    description: If true, after successful commit and no pending [human] tasks, cut the next phase branch off the prior phase commit inside the same origin/staging-based worktree and recurse. Halt on verification fail, [human] gate, scope violation, or next-phase preflight error.
+    description: If true, after successful commit and no pending [human] tasks, cut the next phase branch off the prior phase commit inside the same workflow-base worktree and recurse. Halt on verification fail, [human] gate, scope violation, or next-phase preflight error.
   - name: dry_run
     type: boolean
     default: false
@@ -40,7 +40,7 @@ reads:
   - git log, git status, git branch (to establish HEAD and sync-gate state)
 writes:
   - docs/executions/.phase-runs/<date>[-<plan-slug>]-phase-<N>.md
-  - new git branch `<prefix>/phase-<N>-<slug>` (from `origin/staging` for first live phase, then stacked on the prior phase commit only when auto-proceeding in the same worktree)
+  - new git branch `<prefix>/phase-<N>-<slug>` (from the resolved workflow base for first live phase, then stacked on the prior phase commit only when auto-proceeding in the same worktree)
   - git commits on that branch
 ---
 
@@ -87,6 +87,33 @@ approved `design-plan` exists. Normal vertical issues created by
 `to-issues` and approved by `triage` should be executed by
 `workflow-build-one`, `execute-prd`, or `run-backlog`.
 
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Step 0: Preflight And Parse | required | pending | - |
+| Step 0.5: Resolve Workflow Base | conditional | pending | Required for live runs |
+| Step 1: Partition Tasks | required | pending | - |
+| Step 2: Create Phase Branch | conditional | pending | Skipped only for dry_run |
+| Step 3: Dispatch Auto Clusters | conditional | pending | Runs when auto tasks exist |
+| Step 4: Verify Scope | conditional | pending | Runs after mutations |
+| Step 5: Surface Human Work | conditional | pending | Runs when human tasks exist |
+| Step 6: Verify Behavior | conditional | pending | Runs for live auto work |
+| Step 7: Commit Scoped Changes | conditional | pending | Runs only after verification PASS |
+| Step 8: Write Outcome File | required | pending | - |
+| Step 9: Halt Or Auto-Proceed | required | pending | - |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- Conditional steps may be `skipped` only for `dry_run`, no auto work, no human work, or an explicit halt reason from this skill.
+- Include the final ledger in every halt, handoff, and completion response.
+
 The skill enforces these invariants:
 
 1. **`[human]` tasks are never executed.** Surface them to chat and
@@ -127,7 +154,7 @@ Load these files as needed for the active step:
 ## Core Flow
 
 1. **Preflight and parse.** Confirm a clean working tree, verify the
-   current worktree/branch was cut from `origin/staging`, resolve
+   current worktree/branch was cut from the resolved workflow base, resolve
    `plan_path`, `plan_slug`, date, phase number, target outcome file,
    ID scheme, branch prefix, and phase fields. See
    `references/phase-parsing.md` and `references/branch-naming.md`.
@@ -135,7 +162,7 @@ Load these files as needed for the active step:
    and unknown tasks. Group `[auto]` tasks into clusters by overlapping
    file/module scope. Unknown tasks are warnings and are not executed.
 3. **Create the phase branch.** For the first live phase, create
-   `<prefix>/phase-<N>-<phase-slug>` from `origin/staging` in a fresh
+   `<prefix>/phase-<N>-<phase-slug>` from `<workflow-base-ref>` in a fresh
    worktree. For chained auto-proceed phases, stack on the prior phase
    commit in that same worktree. For `dry_run`, skip branch creation
    and record that in the outcome file.
@@ -181,7 +208,7 @@ Record the chosen exit state, pushed commit or reset baseline, and final `git st
 
 - `dry_run == true` parses and writes an outcome file, but dispatches
   no mutating subagent, creates no branch, and makes no commit.
-- Live runs must start in a fresh worktree cut from `origin/staging`.
+- Live runs must load `setup-worktree/references/base-branch-policy.md`, record `WORKFLOW_BASE_GATE`, and start in a fresh worktree cut from the resolved workflow base.
   Do not execute phases from the primary checkout or a branch based on
   local `main`/`staging`.
 - Existing target outcome file with `resume == false` is fatal. With

--- a/dotfiles/.claude/skills/execute-phase/references/execution-profiles.md
+++ b/dotfiles/.claude/skills/execute-phase/references/execution-profiles.md
@@ -32,9 +32,9 @@ Select profiles in this priority order:
 - **Evidence commands:** prefer absolute-path command invocations when
   output is load-bearing evidence.
 - **Worktree baseline:** live `/execute-phase` runs must start in an
-  isolated worktree cut from `origin/staging`. If a phase halts at a
+  isolated worktree cut from the resolved workflow base. If a phase halts at a
   `[human]` gate, continue resolving inside that worktree or use
-  `/setup-worktree phase=<N>` to create a new origin/staging-based
+  `/setup-worktree phase=<N>` to create a new workflow-base
   worktree.
 - **`dry_run`:** run it before real phase execution when a plan is
   freshly written. It confirms parsing, Verification extraction, and

--- a/dotfiles/.claude/skills/execute-phase/references/resume-and-auto-proceed.md
+++ b/dotfiles/.claude/skills/execute-phase/references/resume-and-auto-proceed.md
@@ -27,7 +27,7 @@ the plan or chat, continue from the next blocked step.
 
 Resume requires a prior outcome file. If `resume == true` and no prior
 outcome file exists, halt. A fresh invocation requires `resume=false`
-and a normal preflight from an origin/staging-based worktree.
+and a normal preflight from a workflow-base worktree.
 
 ## Auto-Proceed
 
@@ -37,7 +37,7 @@ On successful commit and no pending `[human]` tasks:
 - If Phase N+1 does not exist, halt with success: plan complete.
 - Otherwise, recurse into preflight with `phase = N+1`.
 - The next phase branches from the current HEAD only inside the
-  origin/staging-based phase worktree, where current HEAD is now the
+  workflow-base phase worktree, where current HEAD is now the
   phase N commit. Do not auto-proceed from the primary checkout.
 - The next outcome file references the prior phase's outcome file in
   its `## Commits` section as branch ancestry.

--- a/dotfiles/.claude/skills/execute-prd/SKILL.md
+++ b/dotfiles/.claude/skills/execute-prd/SKILL.md
@@ -40,7 +40,7 @@ Pairs well with: workflow-feature (produces PRDs this executes), workflow-build-
 | parent | (required) | Parent PRD issue number or URL |
 | children | (discover) | Child issue numbers/URLs, or discover from parent body |
 | branch_prefix | `codex/<parent-slug>` | Branch prefix for all child branches |
-| base_branch | `origin/staging` | Required base for child worktrees and PR branches |
+| base_branch | resolved workflow base | Required remote base for child worktrees and PR branches |
 | scope | (from parent) | Allowed files/areas; out-of-scope exclusions |
 | verification | (from repo) | Commands to verify implementation |
 
@@ -50,11 +50,34 @@ Pairs well with: workflow-feature (produces PRDs this executes), workflow-build-
 preflight → build-tree → order → [execute children] → reconcile-parent → handoff
 ```
 
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Phase 1: Preflight | required | pending | - |
+| Phase 1.5: Resolve Workflow Base | required | pending | - |
+| Phase 2: Build Issue Tree | required | pending | - |
+| Phase 3: Determine Execution Order | required | pending | - |
+| Phase 4: Execute Children | conditional | pending | Runs for ready children |
+| Phase 5: Reconcile Against Parent | required | pending | - |
+| Phase 6: Parent Handoff | required | pending | - |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- Required steps cannot be skipped. If a child is blocked, mark the child disposition, not the workflow step, as blocked.
+- Include the final ledger in every halt, handoff, and completion response.
+
 ### Phase 1: Preflight
 
 1. Confirm repo and working directory
 2. `git fetch origin --prune`
-3. Confirm `origin/staging` exists. If not, halt and ask the user for the replacement base.
+3. Load `setup-worktree/references/base-branch-policy.md`, resolve `<workflow-base-ref>`, and record `WORKFLOW_BASE_GATE`.
 4. Confirm `gh` auth works
 5. Discover repo conventions:
    - Build/test commands from package.json, Makefile, CI workflows
@@ -118,13 +141,13 @@ waves, and fall back to serial execution when scope is uncertain.
 For each child (parallel within a wave, sequential across waves):
 
 1. **Generate child execution brief** via `prompt-builder --mode child-brief` or `references/child-execution-brief-template.md`
-2. **Create isolated worktree** from `origin/staging`:
+2. **Create isolated worktree** from `<workflow-base-ref>`:
 
    ```
-   git worktree add -b <branch_prefix>/<issue-number>-<child-slug> ../worktrees/<issue-number>-<slug> origin/staging
+   git worktree add -b <branch_prefix>/<issue-number>-<child-slug> ../worktrees/<issue-number>-<slug> <workflow-base-ref>
    ```
 
-3. **Record worktree baseline evidence**: `WORKTREE_BASELINE_GATE: origin/staging -> <branch_prefix>/<issue-number>-<child-slug> @ ../worktrees/<issue-number>-<slug>`
+3. **Record worktree baseline evidence**: `WORKFLOW_BASE_GATE` and `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch_prefix>/<issue-number>-<child-slug> @ ../worktrees/<issue-number>-<slug>`
 4. **Execute** using the `workflow-build-one` chain:
 
    ```

--- a/dotfiles/.claude/skills/humanizer-exec/SKILL.md
+++ b/dotfiles/.claude/skills/humanizer-exec/SKILL.md
@@ -69,4 +69,8 @@ Same skeleton, sharper muscle.
 
 ## Contract
 
-Consumes LLM-drafted exec-bound text → produces cleaned text + a change log. Requires nothing hard (siblings and graph used when present, skipped when not). No side effects unless editing a file in place. **Gate:** if there's no clear recommendation/headline, halt and ask (or route to `decision-memo`); never fabricate one.
+Consumes: LLM-drafted exec-bound text
+Produces: cleaned text and a change log
+Requires: nothing hard; siblings and graph context are used when present and skipped when absent
+Side effects: none unless the user asks to edit a file in place
+Human gates: if there is no clear recommendation/headline, halt and ask or route to `decision-memo`; never fabricate one

--- a/dotfiles/.claude/skills/humanizer/SKILL.md
+++ b/dotfiles/.claude/skills/humanizer/SKILL.md
@@ -10,6 +10,14 @@ codex-compatible: true
 
 Edit text to remove the tells of AI-generated writing so it reads as natural and human. Based on Wikipedia's "Signs of AI writing" guide (WikiProject AI Cleanup). Preserve the author's meaning and intended tone; the goal is to strip AI-isms and add genuine personality, not to rewrite the message.
 
+## Contract
+
+Consumes: text to rewrite or edit
+Produces: draft rewrite, tells found, and final rewrite
+Requires: none; bundled references are loaded only when needed
+Side effects: none unless the user explicitly asks to edit a file
+Human gates: unclear intended meaning, audience, or tone may require clarification before rewriting
+
 ## References — load only what the request needs
 
 - `references/pattern-catalog.md` — the 29 patterns, watch-words, before/after examples. Load it as your checklist for any non-trivial text.

--- a/dotfiles/.claude/skills/lint-skill-suite.sh
+++ b/dotfiles/.claude/skills/lint-skill-suite.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Validate the local skill corpus for workflow-hardening invariants.
+
+set -euo pipefail
+
+root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+runtime_root="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+check_runtime="${CHECK_CODEX_RUNTIME:-0}"
+failures=0
+warnings=0
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    failures=$((failures + 1))
+}
+
+warn() {
+    printf 'WARN: %s\n' "$*" >&2
+    warnings=$((warnings + 1))
+}
+
+has_frontmatter_key() {
+    local file="$1" key="$2"
+    awk -v key="$key" '
+        BEGIN { fm = 0; found = 0 }
+        /^---$/ { fm++; next }
+        fm == 1 && $0 ~ "^" key ":" { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "$file"
+}
+
+frontmatter_value() {
+    local file="$1" key="$2"
+    awk -v key="$key" '
+        /^---$/ { fm++; next }
+        fm == 1 && $0 ~ "^" key ":" {
+            sub("^" key ":[[:space:]]*", "")
+            print
+            exit
+        }
+    ' "$file"
+}
+
+is_top_level_skill() {
+    local dir="$1"
+    [ -f "$dir/SKILL.md" ]
+}
+
+contract_has_field() {
+    local file="$1" field="$2"
+    awk -v field="$field" '
+        /^## Contract$/ { in_contract = 1; next }
+        in_contract && /^## / { in_contract = 0 }
+        in_contract && $0 ~ "^" field ":" { found = 1 }
+        END { exit found ? 0 : 1 }
+    ' "$file"
+}
+
+needs_ledger() {
+    case "$1" in
+        workflow-*|run-backlog|watch-ci|execute-prd|execute-phase) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+[ -d "$root" ] || {
+    echo "skills root not found: $root" >&2
+    exit 2
+}
+
+while IFS= read -r -d '' file; do
+    skill="${file#"$root"/}"
+    skill="${skill%/SKILL.md}"
+    case "$skill" in
+        deprecated/*|docs/*|_personas/*) continue ;;
+    esac
+
+    if ! has_frontmatter_key "$file" name; then
+        fail "$skill missing frontmatter name"
+    fi
+    if ! has_frontmatter_key "$file" description; then
+        fail "$skill missing frontmatter description"
+    fi
+    if awk 'BEGIN { fm = 0 } /^---$/ { fm++; next } fm == 1 && /^[[:space:]]+codex-compatible:/ { found = 1 } END { exit found ? 0 : 1 }' "$file"; then
+        fail "$skill has nested codex-compatible frontmatter; use top-level codex-compatible"
+    fi
+
+    if grep -q 'Status: standalone use deprecated' "$file" && ! has_frontmatter_key "$file" disable-model-invocation; then
+        fail "$skill is standalone-deprecated but lacks disable-model-invocation"
+    fi
+
+    if needs_ledger "$skill" && ! grep -q '^WORKFLOW_STEPS:' "$file"; then
+        fail "$skill lacks WORKFLOW_STEPS ledger"
+    fi
+
+    if grep -q '^## Contract$' "$file"; then
+        for field in Consumes Produces Requires "Side effects" "Human gates"; do
+            if ! contract_has_field "$file" "$field"; then
+                fail "$skill contract missing field: $field"
+            fi
+        done
+    else
+        warn "$skill lacks contract section"
+    fi
+done < <(find "$root" -mindepth 2 -maxdepth 2 -name SKILL.md -print0)
+
+if [ "$check_runtime" = "1" ] && [ -d "$runtime_root" ]; then
+    while IFS= read -r -d '' runtime_file; do
+        skill="${runtime_file#"$runtime_root"/}"
+        skill="${skill%/SKILL.md}"
+        source_file="$root/$skill/SKILL.md"
+        if [ ! -f "$source_file" ]; then
+            fail "Codex runtime has skill not present in active source: $skill"
+            continue
+        fi
+        if [ "$(frontmatter_value "$source_file" codex-compatible)" = "false" ]; then
+            fail "Codex runtime exposes codex-compatible:false source skill: $skill"
+        fi
+    done < <(find "$runtime_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print0)
+fi
+
+printf 'skill-suite lint: failures=%s warnings=%s\n' "$failures" "$warnings"
+[ "$failures" -eq 0 ]

--- a/dotfiles/.claude/skills/lint-skill-suite.sh
+++ b/dotfiles/.claude/skills/lint-skill-suite.sh
@@ -58,7 +58,7 @@ contract_has_field() {
 
 needs_ledger() {
     case "$1" in
-        workflow-*|run-backlog|watch-ci|execute-prd|execute-phase) return 0 ;;
+        workflow-* | run-backlog | watch-ci | execute-prd | execute-phase) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -72,7 +72,7 @@ while IFS= read -r -d '' file; do
     skill="${file#"$root"/}"
     skill="${skill%/SKILL.md}"
     case "$skill" in
-        deprecated/*|docs/*|_personas/*) continue ;;
+        deprecated/* | docs/* | _personas/*) continue ;;
     esac
 
     if ! has_frontmatter_key "$file" name; then

--- a/dotfiles/.claude/skills/metric-council/SKILL.md
+++ b/dotfiles/.claude/skills/metric-council/SKILL.md
@@ -11,6 +11,14 @@ Stress-test a metric design before it becomes load-bearing (a bad metric's cost 
 
 **Mechanics:** follow `council-scaffolding` for dispatch/synthesis/persist. Deltas below.
 
+## Contract
+
+Consumes: metric design, metric tree change, or existing metric behavior to review
+Produces: council synthesis with survivability verdict, critique, falsifiers, and per-expert reads
+Requires: independent expert contexts; graph context optional
+Side effects: may persist synthesis to `.council/metric/` when the run reaches the persistence step
+Human gates: redesign, abandon, governance, or KPI/target promotion decisions require human judgment
+
 ## When to invoke
 
 After `metric-design` (before implementation), auditing an existing metric "not behaving as expected", before promoting to KPI/target/OKR. Routing: design → `metric-design`; implement → `add-metric` (after this); general → `analysis-council`.

--- a/dotfiles/.claude/skills/post-mortem/SKILL.md
+++ b/dotfiles/.claude/skills/post-mortem/SKILL.md
@@ -38,6 +38,14 @@ The pipeline only learns if someone records what actually happened. Compare plan
 
 Standalone use is deprecated; this runs as the conditional retro gate inside `workflow-finalize`. Edge cases, a worked example, and tuning guidance live in `references/edge-cases-and-examples.md` — load it when needed.
 
+## Contract
+
+Consumes: design plan, audit evidence, phase-run and CI-run artifacts, git history, and optional git range
+Produces: blameless post-mortem under `docs/executions/` with resolved findings, drift, new findings, and takeaways
+Requires: git
+Side effects: writes post-mortem artifact; may annotate the source audit only with explicit user opt-in
+Human gates: missing plan/evidence, audit annotation, or unresolved human tasks halt for human input
+
 ## Step 0 — Preflight
 
 Confirm a git repo (else abort). Resolve the plan (`plan_path` or newest `docs/plans/*.md`; if none, abort). Resolve the audit (`audit_path`, else the plan's `**Audit:**` header, else newest audit older than the plan). **Brief-mode** plans (no `**Audit:**`, §5 uses `REQ-NN`/ticket slugs) skip audit resolution and anchor on `REQ-NN`/slugs — note this in §Summary. Resolve the git range (`since`, else `git log --follow --format=%H <plan_path> | tail -1` → `<since>..HEAD`). Pick the ID scheme: `FIND-NN` (audit-mode), `REQ-NN`/slugs (brief-mode), or phase-based if neither. `mkdir -p docs/executions/`.

--- a/dotfiles/.claude/skills/prompt-builder/SKILL.md
+++ b/dotfiles/.claude/skills/prompt-builder/SKILL.md
@@ -92,7 +92,7 @@ Example: `workflow-build-one` — this is a ready-for-agent issue with clear acc
 ## Constraints
 
 [Any constraints extracted from labels, related issues, or project conventions]
-- Must create a fresh per-issue worktree from `origin/staging` before starting implementation and include `WORKTREE_BASELINE_GATE` in the handoff
+- Must resolve `WORKFLOW_BASE_GATE`, create a fresh per-issue worktree from the resolved workflow base before starting implementation, and include `WORKTREE_BASELINE_GATE` in the handoff
 - For dependent stacked work, may instead create a fresh per-issue worktree from the clean parent branch only when the parent PR has complete gates; include `STACKED_WORKTREE_GATE` and target the PR at the parent branch
 - Must run `workflow-review` with a risk-sized `review_profile` and include `WORKFLOW_REVIEW_GATE` with `independent_review: true` and `verdict: APPROVE`
 - Must run `workflow-finalize` and include a complete `WORKFLOW_FINALIZE_GATE`
@@ -124,10 +124,10 @@ Example: `workflow-build-one` — this is a ready-for-agent issue with clear acc
 
 - Be more explicit about file paths (Codex can't browse interactively)
 - Include the full acceptance criteria (no "see issue for details")
-- For root issues, include the exact mandatory per-issue worktree command before any code changes: `git fetch origin --prune && git worktree add -b <issue-branch> <issue-worktree-path> origin/staging`
-- For root issues, require final handoff evidence: `WORKTREE_BASELINE_GATE: origin/staging -> <branch> @ <path>`
-- For stacked dependent work, do not include the root `origin/staging` worktree command as the implementation command. Include the parent-gate precondition, create the child worktree from the parent branch with `git worktree add -b <child-branch> <child-worktree-path> <parent-branch>`, target the child PR at the parent branch, and require final handoff evidence:
-  `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete`
+- For root issues, include the exact mandatory base-resolution and per-issue worktree command before any code changes: `git fetch origin --prune && <resolve WORKFLOW_BASE_GATE> && git worktree add -b <issue-branch> <issue-worktree-path> <workflow-base-ref>`
+- For root issues, require final handoff evidence: `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch> @ <path>`
+- For stacked dependent work, do not include the root workflow-base worktree command as the implementation command. Include the parent-gate precondition, create the child worktree from the parent branch with `git worktree add -b <child-branch> <child-worktree-path> <parent-branch>`, target the child PR at the parent branch, and require final handoff evidence:
+  `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete`
 - Require `workflow-review` with a real `WORKFLOW_REVIEW_GATE`, `review_profile`, `independent_review: true`, and `verdict: APPROVE`; green CI, GitHub reviews, Claude Code Review, Bugbot, or Codex review do not substitute for this gate.
 - Require `workflow-finalize` with a complete `WORKFLOW_FINALIZE_GATE`.
 - If the issue has `needs-human-review`, `Human review: required`, or an equivalent human-review gate, include the issue's `## Reviewer validation steps` in the prompt and require the worker to preserve them through `describe-pr`/`workflow-finalize` so the PR body ends with the same section.
@@ -162,7 +162,7 @@ Print the prompt to chat. Then offer:
 ## Rules
 
 - Never fabricate acceptance criteria. If criteria are absent or materially ambiguous, halt AFK prompt generation and mark the issue `needs-human`. `[inferred]` criteria are allowed only for planning briefs, not execution prompts.
-- Never generate a root execution prompt that omits mandatory per-issue worktree creation from `origin/staging`. If the issue cannot name a safe branch/worktree convention, include placeholders and require the worker to resolve them before coding.
+- Never generate a root execution prompt that omits `WORKFLOW_BASE_GATE` and mandatory per-issue worktree creation from the resolved workflow base. If the issue cannot name a safe branch/worktree convention, include placeholders and require the worker to resolve them before coding.
 - Never generate a stacked execution prompt unless the parent PR gate evidence is complete and the prompt tells the worker to target the child PR at the parent branch.
 - Never generate an execution prompt that omits `workflow-review`, risk-sized `review_profile`, `WORKFLOW_REVIEW_GATE`, `workflow-finalize`, `WORKFLOW_FINALIZE_GATE`, draft-only PR handoff, and no mark-ready/merge/auto-merge/destructive-git constraints.
 - Never generate an execution prompt for a human-review-required issue that omits `Human review: required` and the issue's concrete `## Reviewer validation steps`.

--- a/dotfiles/.claude/skills/receive-review/SKILL.md
+++ b/dotfiles/.claude/skills/receive-review/SKILL.md
@@ -12,7 +12,11 @@ Evaluate code-review feedback with technical rigor, then process the whole comme
 
 ## Contract
 
-Consumes: PR number/URL, review comments (bot or human), code context, original intent. Produces: a triage table with verdicts, grouped fix commits, inline replies for every active thread, and a summary. Requires: `gh`, `git`, local test/lint runner. Side effects: pushes fix commits, posts replies, may file follow-up issues. Human gates: surface the summary before pushing; disagreements with **human** reviewers go to the user for decision before replying; push-back replies are higher-stakes — confirm first.
+Consumes: PR number/URL, review comments (bot or human), code context, original intent
+Produces: a triage table with verdicts, grouped fix commits, inline replies for every active thread, and a summary
+Requires: `gh`, `git`, local test/lint runner
+Side effects: pushes fix commits, posts replies, may file follow-up issues
+Human gates: surface the summary before pushing; disagreements with **human** reviewers go to the user for decision before replying; push-back replies are higher-stakes — confirm first
 
 ## When to invoke
 

--- a/dotfiles/.claude/skills/repo-audit/SKILL.md
+++ b/dotfiles/.claude/skills/repo-audit/SKILL.md
@@ -15,7 +15,13 @@ Give an evidence-based picture of where a repo actually is — not what its docs
 
 ## Contract
 
-Consumes: codebase (or scoped subtree), README, CLAUDE.md, spec docs. Produces: audit report with stable FIND-NN IDs at `docs/audits/<date>-repo-audit.md`. Requires: git. Side effects: writes the audit + intermediate fact-packs (fact-packs deleted by default). Feeds: workflow-roadmap, to-prd, to-issues, triage, design-plan.
+Consumes: codebase (or scoped subtree), README, CLAUDE.md, spec docs
+Produces: audit report with stable FIND-NN IDs at `docs/audits/<date>-repo-audit.md`
+Requires: git
+Side effects: writes the audit and intermediate fact-packs; fact-packs are deleted by default
+Human gates: none by default; halt if required repo context or evidence paths are unavailable
+
+Feeds: workflow-roadmap, to-prd, to-issues, triage, design-plan.
 
 ## Step 0 — Preflight
 

--- a/dotfiles/.claude/skills/run-backlog/SKILL.md
+++ b/dotfiles/.claude/skills/run-backlog/SKILL.md
@@ -32,6 +32,30 @@ Before Phase 1, load `references/outage-risk-policy.md` and `references/repo-del
 - `outage-risk-policy.md` decides whether an issue is AFK-safe; a priority label does not override it.
 - `repo-delivery-policy.md` decides whether the current repository is `human-only` or `auto-merge-eligible`.
 
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Phase 0: Resolve Repository Delivery Policy | required | pending | - |
+| Phase 0.5: Resolve Workflow Base | required | pending | - |
+| Phase 1: Plan Queue | required | pending | - |
+| Phase 1.5: Queue Approval | conditional | pending | Auto-approved only for explicit AFK request |
+| Phase 2: Dispatch | conditional | pending | Runs for approved queue |
+| Phase 3: Monitor | conditional | pending | Runs after dispatch |
+| Phase 4: Reconcile And Handoff | required | pending | - |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- Required steps cannot be skipped. If repository policy, base resolution, or issue lookup cannot run, mark the step `blocked` and halt.
+- Queue approval may be `skipped` only when the current invocation explicitly requested unattended/AFK execution.
+- Include the final ledger in every halt, handoff, and completion response.
+
 ### Phase 0: Resolve repository delivery policy
 
 1. Resolve the current repository with `gh repo view --json nameWithOwner`.
@@ -47,6 +71,10 @@ REPO_DELIVERY_POLICY:
 ```
 
 If repository identity cannot be resolved, halt before dispatch. Do not guess and do not default to auto-merge.
+
+### Phase 0.5: Resolve workflow base
+
+Load `setup-worktree/references/base-branch-policy.md`, run `git fetch origin --prune`, resolve `<workflow-base-ref>`, and record `WORKFLOW_BASE_GATE` in the queue artifact. All root issue worktrees, prompts, and handoffs use this resolved base.
 
 ### Phase 1: Plan
 
@@ -78,19 +106,19 @@ For each issue in queue order:
 
 1. Apply `in-progress` label
 2. Create or require the issue's worktree before repo/code context gathering:
-   - **Root issue**: create from `origin/staging`.
-   - `git fetch origin --prune && git worktree add -b <issue-branch> <issue-worktree-path> origin/staging`
-   - Record `WORKTREE_BASELINE_GATE: origin/staging -> <issue-branch> @ <issue-worktree-path>` in the queue artifact.
+   - **Root issue**: create from `<workflow-base-ref>`.
+   - `git fetch origin --prune && git worktree add -b <issue-branch> <issue-worktree-path> <workflow-base-ref>`
+   - Record `WORKFLOW_BASE_GATE` and `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <issue-branch> @ <issue-worktree-path>` in the queue artifact.
    - **Stacked dependent issue**: only allowed when the parent PR has `WORKTREE_BASELINE_GATE`, `WORKFLOW_REVIEW_GATE` with `review_profile`, `independent_review: true`, and `verdict: APPROVE`, a complete `WORKFLOW_FINALIZE_GATE`, green CI, and no unresolved reviewer comments.
    - Create the dependent worktree from the parent branch, target the dependent PR at the parent branch, and record:
-     `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete`
+     `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete`
    - If worktree creation fails, remove `in-progress`, add `needs-human`, and do not dispatch.
 3. Generate prompt via `prompt-builder` from inside that per-issue worktree:
    - Pass the issue number and target tool (codex or claude)
    - prompt-builder gathers repo/code context only after the per-issue worktree exists, determines execution strategy, and produces a structured prompt
    - In Codex mode, the generated prompt is the primary input to the dispatch (Codex cannot ask clarifying questions)
    - In Claude mode, the prompt seeds workflow-build-one with pre-gathered context
-   - The prompt must instruct the worker to use this per-issue worktree, verify either `WORKTREE_BASELINE_GATE` or `STACKED_WORKTREE_GATE`, and include the matching gate evidence in the handoff.
+   - The prompt must instruct the worker to use this per-issue worktree, verify `WORKFLOW_BASE_GATE` plus either `WORKTREE_BASELINE_GATE` or `STACKED_WORKTREE_GATE`, and include the matching gate evidence in the handoff.
    - If the prompt lacks the per-issue worktree/stack command or gate requirement, do not dispatch the issue; regenerate the prompt or mark the issue `needs-human`.
    - If the issue has `needs-human-review`, `Human review: required`, or an equivalent human-review gate, the prompt must include the issue's concrete `## Reviewer validation steps` and instruct the worker to preserve them through `describe-pr`/`workflow-finalize` so the PR body ends with that section.
    - The prompt must include `REPO_DELIVERY_POLICY` and instruct the worker to follow it:
@@ -108,7 +136,7 @@ For each issue in queue order:
 
 1. Poll PR status: `gh pr list --state open --json number,title,isDraft,statusCheckRollup`
 2. For each completed dispatch:
-   - PR or handoff lacks `WORKTREE_BASELINE_GATE: origin/staging -> ...` or valid `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> ...` → flag `needs-human`; do not accept work from primary checkout or a local-main branch
+   - PR or handoff lacks `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> ...` or valid `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> ...` → flag `needs-human`; do not accept work from primary checkout or a local-main branch
    - Stacked PR does not target its parent branch, or parent gate evidence is missing/stale → flag `needs-human`
    - PR lacks a complete `WORKFLOW_REVIEW_GATE` block with `review_profile`, `independent_review: true`, and `verdict: APPROVE` → flag `needs-human`; green CI or GitHub/Claude/Codex/Bugbot review does not satisfy the review gate
    - PR lacks a complete `WORKFLOW_FINALIZE_GATE` block → flag `needs-human`; a PR URL, draft PR, or green CI alone does not satisfy finalization
@@ -167,7 +195,7 @@ Work queue artifact is written to `docs/executions/backlog-runs/[date].md` for a
 - Do not skip `needs-human-review`; carry its reviewer validation steps into the worker prompt and final PR body.
 - If an issue's acceptance criteria are unclear, skip it and add `needs-human` label
 - Never dispatch dependency chains in parallel unless using the stacked development rules above.
-- Every dispatched root issue must create its own fresh `origin/staging` worktree before code changes; stacked dependent issues must create their own fresh worktree from the clean parent branch. Shared worktrees and primary-checkout work are invalid.
+- Every dispatched root issue must create its own fresh worktree from the resolved workflow base before code changes; stacked dependent issues must create their own fresh worktree from the clean parent branch. Shared worktrees and primary-checkout work are invalid.
 - Every dispatched worker must satisfy the Partial-Completion Contract before exit: Complete and pushed, WIP-paused with a pushed `wip:` commit naming exactly what remains, or Rolled back to the baseline with a clean worktree. A dirty source tree after `git status --short` is never an acceptable AFK exit.
 - Apply `references/outage-risk-policy.md` before dispatch and again before marking outcomes successful
 - Apply `references/repo-delivery-policy.md` before dispatch and before any final PR action

--- a/dotfiles/.claude/skills/run-backlog/references/outage-risk-policy.md
+++ b/dotfiles/.claude/skills/run-backlog/references/outage-risk-policy.md
@@ -42,7 +42,7 @@ Each queued issue must include:
 - Dispatch only `low` or explicitly approved `medium` risk items in AFK mode.
 - Dispatch dependency chains sequentially, or use stacked development only when the parent PR has complete clean gates and the child PR targets the parent branch.
 - Never dispatch issues that modify the same files or modules in parallel.
-- Use a fresh `origin/staging` worktree per root issue. Stacked dependent issues must use a fresh worktree from the clean parent branch and record `STACKED_WORKTREE_GATE`.
+- Resolve `WORKFLOW_BASE_GATE` first. Use a fresh worktree from the resolved workflow base per root issue. Stacked dependent issues must use a fresh worktree from the clean parent branch and record `STACKED_WORKTREE_GATE`.
 - Require `WORKTREE_BASELINE_GATE`, `WORKFLOW_REVIEW_GATE`, and `WORKFLOW_FINALIZE_GATE` before marking any item successful.
 
 ## Halt Rules

--- a/dotfiles/.claude/skills/setup-worktree/SKILL.md
+++ b/dotfiles/.claude/skills/setup-worktree/SKILL.md
@@ -2,7 +2,8 @@
 name: setup-worktree
 model: haiku
 reasoning: medium
-description: "Create an isolated git worktree from origin/staging for a plan phase, issue, or workflow run; defaults path ~/wt/<repo>/phase-<N>/, derives the branch, auto-copies .env*/.tool-versions etc. Used before workflow execution and at human-gate halts."
+description: "Create an isolated git worktree from the resolved workflow base branch for a plan phase, issue, or workflow run; defaults path ~/wt/<repo>/phase-<N>/, derives the branch, auto-copies .env*/.tool-versions etc. Used before workflow execution and at human-gate halts."
+disable-model-invocation: true
 triggers:
   - "/setup-worktree"
   - "setup worktree"
@@ -21,7 +22,7 @@ inputs:
   - name: branch
     type: string
     default: ""
-    description: Branch name. If empty and `plan_path`/`phase` set, derive `refactor/phase-<N>-<plan-phase-slug>`. New branches are created from `origin/staging`; existing branches are allowed only when explicitly reviewing or resuming that branch.
+    description: Branch name. If empty and `plan_path`/`phase` set, derive `refactor/phase-<N>-<plan-phase-slug>`. New branches are created from the resolved workflow base; existing branches are allowed only when explicitly reviewing or resuming that branch.
   - name: path
     type: string
     default: ""
@@ -33,6 +34,7 @@ inputs:
 reads:
   - docs/plans/<date>-design.md (when deriving branch from plan+phase)
   - git, current checkout (for branch existence + env file sources)
+  - references/base-branch-policy.md
 writes:
   - new worktree directory at <path>
   - new git branch (if `branch` doesn't already exist)
@@ -65,7 +67,7 @@ Pairs well with: execute-phase, workflow-finalize, watch-ci, design-plan, workfl
 ## Purpose
 
 Workflows that mutate code should start in a fresh isolated worktree
-cut from `origin/staging`. This skill creates that worktree, copies the
+cut from the resolved workflow base branch. This skill creates that worktree, copies the
 env/config files that new checkouts usually need, and optionally runs a
 setup command. The worktree is discardable — `git worktree remove
 <path>` when done.
@@ -76,8 +78,8 @@ standalone, on-demand side-car for halted human gates.
 ## Step 0: Preflight
 
 - Confirm a git repo.
-- Run `git fetch origin --prune` before reasoning about branches.
-- Verify `origin/staging` exists. If not, halt and ask the user which remote base should replace it.
+- Load `references/base-branch-policy.md`, run `git fetch origin --prune`, and resolve `<workflow-base-ref>`.
+- Record `WORKFLOW_BASE_GATE` with the preferred base, resolved base, fallback reason, and `fetched: true`.
 - Resolve inputs into a concrete `(branch, path, setup_command)` triple:
   - **If `branch` and `path` both set:** use them.
   - **Else if `plan_path` and `phase` set** (most common caller from `/execute-phase` halt):
@@ -87,15 +89,15 @@ standalone, on-demand side-car for halted human gates.
   - **Else if `plan_path` empty but `phase` non-zero:** fall back to newest `docs/plans/*.md` for `plan_path`, then derive as above.
   - **Else:** abort with a clear message: need either `(branch, path)` or `(plan_path, phase)` (or at least `phase` with a newest plan on disk).
 - Verify `path` doesn't already exist. Abort if it does (would require `git worktree add --force`, which we won't do silently).
-- Verify `branch` can be created as a new local branch from `origin/staging`. If it already exists, halt unless the user explicitly requested branch review/resume mode.
-- Before checking out an existing branch for explicit review/resume mode, verify it has `WORKTREE_BASELINE_GATE` evidence or ancestry from `origin/staging`. Otherwise halt and recreate the work in a fresh origin/staging-based worktree.
+- Verify `branch` can be created as a new local branch from `<workflow-base-ref>`. If it already exists, halt unless the user explicitly requested branch review/resume mode.
+- Before checking out an existing branch for explicit review/resume mode, verify it has `WORKTREE_BASELINE_GATE` evidence or ancestry from the resolved workflow base. Otherwise halt and recreate the work in a fresh workflow-base worktree.
 
 ## Step 1: Create the worktree
 
 Single inlined command (no external `scripts/create_worktree.sh`):
 
 - **Normal workflow mode:**
-  `git worktree add -b "<branch>" "<path>" origin/staging` — creates a fresh branch from `origin/staging`.
+  `git worktree add -b "<branch>" "<path>" "<workflow-base-ref>"` — creates a fresh branch from the resolved workflow base.
 - **Explicit review/resume mode only:**
   `git worktree add "<path>" "<branch>"` — checks out the existing branch in the new worktree.
 
@@ -135,6 +137,7 @@ If `setup_command` is empty, record `setup_command: not provided` in the summary
 Print to chat:
 
 - One-line result: "Worktree created at `<path>` on branch `<branch>`."
+- `WORKFLOW_BASE_GATE` and `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch> @ <path>`
 - List of copied config files (or "no env/config files found").
 - Setup command outcome if run (exit code + short tail of output).
 - Next step if derived from a plan phase:
@@ -171,6 +174,7 @@ Claude: [preflight — newest plan: docs/plans/2026-04-20-design.md;
          derived branch: refactor/phase-2-skill-scaffolding;
          derived path: ~/wt/myrepo/phase-2/]
         [git fetch origin --prune]
+        [WORKFLOW_BASE_GATE: resolved_base=origin/staging]
         [git worktree add -b refactor/phase-2-skill-scaffolding ~/wt/myrepo/phase-2/ origin/staging]
         [copied .env, .nvmrc, .claude/settings.local.json]
         [no setup_command specified]
@@ -188,7 +192,8 @@ Explicit branch + path + setup command:
 ```
 User: /setup-worktree branch=fix/flaky-test path=~/wt/myrepo/flaky setup_command="bun install"
 Claude: [git fetch origin --prune]
-        [git worktree add -b fix/flaky-test ~/wt/myrepo/flaky origin/staging]
+        [WORKFLOW_BASE_GATE: resolved_base=origin/main, fallback_reason=origin/staging_absent]
+        [git worktree add -b fix/flaky-test ~/wt/myrepo/flaky origin/main]
         [copied .env.local, .nvmrc]
         [bun install: exit 0, 312 packages installed]
 
@@ -199,7 +204,7 @@ Claude: [git fetch origin --prune]
 ## Tuning notes
 
 - **No primary-checkout resolution.** Resolve halted work inside the
-  origin/staging-based phase worktree. If the halt happened in the
+  workflow-base phase worktree. If the halt happened in the
   primary checkout, stop and recreate the work in a fresh worktree
   before making further changes.
 

--- a/dotfiles/.claude/skills/setup-worktree/references/base-branch-policy.md
+++ b/dotfiles/.claude/skills/setup-worktree/references/base-branch-policy.md
@@ -1,0 +1,49 @@
+# Workflow Base Branch Policy
+
+Load this before creating or validating a workflow worktree.
+
+## Resolution
+
+1. Run `git fetch origin --prune`.
+2. Prefer `origin/staging` when it exists.
+3. If `origin/staging` is absent, resolve the remote default branch:
+
+   ```bash
+   git remote show origin | sed -n '/HEAD branch/s/.*: //p'
+   ```
+
+4. Use `origin/<default-branch>` only when that remote ref exists.
+5. If neither `origin/staging` nor a valid remote default ref exists, halt and ask the user for the workflow base.
+
+## Gate
+
+Every mutating workflow must record the resolved base before implementation:
+
+```markdown
+WORKFLOW_BASE_GATE:
+  preferred_base: origin/staging
+  resolved_base: origin/staging|origin/<default-branch>
+  fallback_reason: not_applicable|origin/staging_absent
+  fetched: true
+```
+
+Worktree and review/finalize gates must use `resolved_base`, not a hard-coded branch.
+
+Examples:
+
+```markdown
+WORKFLOW_BASE_GATE:
+  preferred_base: origin/staging
+  resolved_base: origin/main
+  fallback_reason: origin/staging_absent
+  fetched: true
+
+WORKTREE_BASELINE_GATE: origin/main -> codex/example @ /Users/alexwelch/wt/repo/example
+```
+
+## Rules
+
+- Do not use local `main`, local `staging`, or an unfetched cached ref as the base.
+- Do not silently fall back to `origin/main`; record `WORKFLOW_BASE_GATE`.
+- Stacked child worktrees still record the original resolved base in `STACKED_WORKTREE_GATE`.
+- If a repository has a documented protected integration branch, add that policy to repo docs and treat it as the preferred base for that repo.

--- a/dotfiles/.claude/skills/slop-cleaner/SKILL.md
+++ b/dotfiles/.claude/skills/slop-cleaner/SKILL.md
@@ -14,6 +14,14 @@ LLM output often *looks* thorough but buries the load-bearing content in ceremon
 
 (For general persuasive prose use `humanizer`; for actual code cleanup — dead code, duplication, wrappers — use `ai-slop-cleaner`.)
 
+## Contract
+
+Consumes: LLM-drafted documentation, analysis, comments, docstrings, runbooks, memos, or recommendations
+Produces: cleaned text plus change log and before/after word counts when available
+Requires: none
+Side effects: none unless the user explicitly asks to edit a file
+Human gates: unclear purpose, missing evidence, or load-bearing ambiguity is flagged rather than invented
+
 ## Process (both modes)
 
 1. **Read** the input; identify its type/scope (different doc types tolerate different explanation levels).

--- a/dotfiles/.claude/skills/sync-codex-skills.sh
+++ b/dotfiles/.claude/skills/sync-codex-skills.sh
@@ -22,8 +22,15 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --apply) apply=1 ;;
         --prune) prune=1 ;;
-        -h|--help) usage; exit 0 ;;
-        *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
     esac
     shift
 done
@@ -53,7 +60,7 @@ while IFS= read -r -d '' skill_file; do
     skill="${skill_file#"$source_root"/}"
     skill="${skill%/SKILL.md}"
     case "$skill" in
-        deprecated/*|docs/*|_personas/*) continue ;;
+        deprecated/* | docs/* | _personas/*) continue ;;
     esac
     if [ "$(frontmatter_value "$skill_file" codex-compatible)" = "false" ]; then
         printf 'skip codex-incompatible: %s\n' "$skill"

--- a/dotfiles/.claude/skills/sync-codex-skills.sh
+++ b/dotfiles/.claude/skills/sync-codex-skills.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Sync dotdev skill source into the Codex runtime. Dry-run by default.
+
+set -euo pipefail
+
+source_root="${SOURCE_SKILLS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+runtime_root="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+apply=0
+prune=0
+
+usage() {
+    cat <<'USAGE'
+Usage: sync-codex-skills.sh [--apply] [--prune]
+
+Default is dry-run. --apply copies active source skills to the Codex runtime.
+--prune includes runtime skills that are not active source skills or are
+codex-incompatible in the dry run; with --apply, those skills are removed.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --apply) apply=1 ;;
+        --prune) prune=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+[ -d "$source_root" ] || {
+    echo "source skills root not found: $source_root" >&2
+    exit 2
+}
+
+mkdir -p "$runtime_root"
+
+frontmatter_value() {
+    local file="$1" key="$2"
+    awk -v key="$key" '
+        /^---$/ { fm++; next }
+        fm == 1 && $0 ~ "^" key ":" {
+            sub("^" key ":[[:space:]]*", "")
+            print
+            exit
+        }
+    ' "$file"
+}
+
+copy_count=0
+skip_count=0
+while IFS= read -r -d '' skill_file; do
+    skill="${skill_file#"$source_root"/}"
+    skill="${skill%/SKILL.md}"
+    case "$skill" in
+        deprecated/*|docs/*|_personas/*) continue ;;
+    esac
+    if [ "$(frontmatter_value "$skill_file" codex-compatible)" = "false" ]; then
+        printf 'skip codex-incompatible: %s\n' "$skill"
+        skip_count=$((skip_count + 1))
+        continue
+    fi
+    action="would sync"
+    [ "$apply" = "1" ] && action="sync"
+    printf '%s %s -> %s\n' "$action" "$skill" "$runtime_root/$skill"
+    if [ "$apply" = "1" ]; then
+        rm -rf "${runtime_root:?}/$skill"
+        cp -R "$source_root/$skill" "${runtime_root:?}/$skill"
+    fi
+    copy_count=$((copy_count + 1))
+done < <(find "$source_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print0)
+
+if [ "$prune" = "1" ]; then
+    while IFS= read -r -d '' runtime_file; do
+        skill="${runtime_file#"$runtime_root"/}"
+        skill="${skill%/SKILL.md}"
+        if [ ! -f "$source_root/$skill/SKILL.md" ] ||
+            [ "$(frontmatter_value "$source_root/$skill/SKILL.md" codex-compatible)" = "false" ]; then
+            action="would prune"
+            [ "$apply" = "1" ] && action="prune"
+            printf '%s runtime-only/incompatible: %s\n' "$action" "$skill"
+            if [ "$apply" = "1" ]; then
+                rm -rf "${runtime_root:?}/$skill"
+            fi
+        fi
+    done < <(find "$runtime_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print0)
+fi
+
+printf 'codex skill sync complete: copy_candidates=%s skipped=%s apply=%s prune=%s runtime=%s\n' \
+    "$copy_count" "$skip_count" "$apply" "$prune" "$runtime_root"

--- a/dotfiles/.claude/skills/to-issues/SKILL.md
+++ b/dotfiles/.claude/skills/to-issues/SKILL.md
@@ -154,7 +154,7 @@ Avoid specific file paths or code snippets — they go stale fast. Exception: if
 - Module grill evidence: completed / not applicable, with link or summary
 - Decision log: relevant entries linked / not applicable
 - User-journey QA: required / not applicable, with reason
-- Worktree policy: this issue must create its own fresh worktree from `origin/staging` before implementation starts and report `WORKTREE_BASELINE_GATE: origin/staging -> <branch> @ <worktree-path>`
+- Worktree policy: this issue must resolve `WORKFLOW_BASE_GATE`, create its own fresh worktree from the resolved workflow base before implementation starts, and report `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch> @ <worktree-path>`
 - Review/finalize policy: PR handoff requires `WORKFLOW_REVIEW_GATE` with `review_profile`, `independent_review: true`, and `verdict: APPROVE`, plus a complete `WORKFLOW_FINALIZE_GATE`
 
 ## Reviewer validation steps

--- a/dotfiles/.claude/skills/to-prd/SKILL.md
+++ b/dotfiles/.claude/skills/to-prd/SKILL.md
@@ -135,7 +135,7 @@ A list of testing decisions that were made. Include:
 
 ## AFK Readiness
 
-State whether this PRD can produce AFK-safe issues. Include required verification commands, expected `user-journey-qa` coverage when applicable, and the implementation policy that all code work starts from a fresh `origin/staging` worktree with `WORKTREE_BASELINE_GATE` evidence.
+State whether this PRD can produce AFK-safe issues. Include required verification commands, expected `user-journey-qa` coverage when applicable, and the implementation policy that all code work resolves `WORKFLOW_BASE_GATE`, then starts from a fresh workflow-base worktree with `WORKTREE_BASELINE_GATE` evidence.
 
 State explicitly that child implementation issues must be vertical slices. If the work cannot yet be sliced vertically, mark the PRD as needing more design before issue creation.
 

--- a/dotfiles/.claude/skills/triage/SKILL.md
+++ b/dotfiles/.claude/skills/triage/SKILL.md
@@ -72,8 +72,8 @@ Human-review semantics:
 - rollback expectation
 - AFK/HITL classification
 - outage-risk classification
-- mandatory per-issue `origin/staging` worktree policy
-- exact gate requirement: `WORKTREE_BASELINE_GATE: origin/staging -> <branch> @ <worktree-path>`
+- mandatory per-issue workflow-base worktree policy
+- exact gate requirement: `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch> @ <worktree-path>`
 - review/finalize policy
 - `Human review: required|not required`
 - if `Human review: required`, a `## Reviewer validation steps` section
@@ -111,7 +111,7 @@ Show counts and a one-line summary per issue. Let the maintainer pick.
 4. **Grill (if needed).** If the issue needs fleshing out, run a `/grill-with-docs` session.
 
 5. **Apply the outcome:**
-   - `ready-for-agent` — post an agent brief comment ([AGENT-BRIEF.md](AGENT-BRIEF.md)) that includes the exact `WORKTREE_BASELINE_GATE: origin/staging -> <branch> @ <worktree-path>` requirement. If the issue carries `needs-human-review`, the brief must preserve the `Human review: required` field and `## Reviewer validation steps`.
+   - `ready-for-agent` — post an agent brief comment ([AGENT-BRIEF.md](AGENT-BRIEF.md)) that includes the exact `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch> @ <worktree-path>` requirement. If the issue carries `needs-human-review`, the brief must preserve the `Human review: required` field and `## Reviewer validation steps`.
    - `ready-for-human` — same structure as an agent brief, but note why it can't be delegated (judgment calls, external access, design decisions, manual testing).
    - `needs-info` — post triage notes (template below).
    - `wontfix` (bug) — polite explanation, then close.

--- a/dotfiles/.claude/skills/vendor-council/SKILL.md
+++ b/dotfiles/.claude/skills/vendor-council/SKILL.md
@@ -11,6 +11,14 @@ Vendor decisions are usually one-way doors made on incomplete info; most evaluat
 
 **Mechanics:** follow `council-scaffolding`. Deltas below.
 
+## Contract
+
+Consumes: vendor decision context, candidate vendors, proposed terms, alternatives, and constraints
+Produces: council synthesis with recommendation, risks, counterfactuals, falsifiers, and per-expert reads
+Requires: independent expert contexts; graph context optional
+Side effects: may persist synthesis to `.council/vendor/` when the run reaches the persistence step
+Human gates: vendor commitment, contract, renewal, governance, or spend decisions require human approval
+
 ## When to invoke
 
 Build-vs-buy, selection between 2–4 candidates, renewal (esp. cost/contract changes), risk audit (post-change/post-incident). Routing: broad analysis → `analysis-council`; pricing alone → `analysis-council --council economist,decision-scientist`; governance-only → `governance-reviewer` inline. High-stakes (>$100k or >2y) should also route to `strategic-analysis-review` before committing.

--- a/dotfiles/.claude/skills/watch-ci/SKILL.md
+++ b/dotfiles/.claude/skills/watch-ci/SKILL.md
@@ -106,6 +106,32 @@ Load references only at the point they are needed:
 - `references/exhaustion-handoff.md`: no-progress or exhausted-attempt handoff artifacts.
 - `references/examples.md`: expected behavior examples and larger workflow context.
 
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Step 0: Preflight | required | pending | - |
+| Step 1: Poll CI | required | pending | - |
+| Step 2: Classify Failures | conditional | pending | Runs when CI fails |
+| Step 3: Check Progress And Dispatch Fixes | conditional | pending | Runs for auto-fixable failures |
+| Step 4: Monitor Review Agents And Incorporate Feedback | required | pending | - |
+| Step 5: Halt Path | conditional | pending | Runs on blocker |
+| Step 6: Post Comment And Hand Back PR To Caller | conditional | pending | Runs on green/clean handoff |
+| Step 7: Write Outcome File | required | pending | - |
+| Step 8: Surface To User | required | pending | - |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- Conditional steps may be `skipped` only when their trigger does not occur; record the reason.
+- Required steps cannot be skipped. If preflight, CI polling, review monitoring, or outcome writing cannot run, mark the step `blocked` and halt.
+- Include the final ledger in every halt, outcome file, and completion response.
+
 ## Core Flow
 
 ### Step 0: Preflight

--- a/dotfiles/.claude/skills/workflow-autonomous-backlog/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-autonomous-backlog/SKILL.md
@@ -25,6 +25,32 @@ Requires: gh, git, omc, subagent-dispatch, project-test-runner
 Side effects: creates GitHub issues, dispatches implementation work, creates branches/PRs through child workflows, writes handoff artifacts
 Human gates: module design summary approval; AFK queue approval unless explicitly requested unattended; high-risk outage categories halt; final release remains human-only only for repos classified `human-only` by `run-backlog/references/repo-delivery-policy.md`
 
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Step 1: Discover Module Candidates | required | pending | - |
+| Step 2: Classify Candidates | required | pending | - |
+| Step 3: Module Grilling Gate | conditional | pending | Runs for module-prd-ready candidates |
+| Step 3.1: Module Grill Consensus | conditional | pending | Runs after module grill |
+| Step 3.5: Optional Scoped Second Architecture Pass | conditional | pending | Runs when grill identifies internal friction |
+| Step 4: Create PRDs And Issues | conditional | pending | Runs for approved candidates |
+| Step 5: Prepare AFK Queue | conditional | pending | Runs when execution requested |
+| Step 6: Execute Backlog | conditional | pending | Runs after AFK approval |
+| Step 7: Handoff | required | pending | - |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- Conditional steps may be `skipped` only with an explicit reason such as no approved candidates or no AFK execution approval.
+- Required steps cannot be skipped. If discovery, classification, or handoff cannot run, mark blocked and halt.
+- Include the final ledger in every halt, handoff, and completion response.
+
 ## Flow
 
 ### 1. Discover module candidates
@@ -153,7 +179,7 @@ Required summary fields:
 - Use `to-prd` only for approved `module-prd-ready` candidates.
 - Use `to-issues` to split each PRD into vertical slices.
 - Every issue must include clear acceptance criteria, dependency order, AFK/HITL classification, outage-risk classification, verification expectations, and the worktree rule:
-  `WORKTREE_BASELINE_GATE: origin/staging -> <branch> @ <worktree-path>`.
+  `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <branch> @ <worktree-path>`.
 - Run `/triage` on every child implementation issue after creation. `/triage` owns the labels and agent brief required for execution.
 - Only `/triage` may apply `ready-for-agent`, and only to issues with clear acceptance criteria, no unresolved human decisions, an executable verification path, AFK-safe risk classification, rollback expectations, the exact worktree gate requirement, review/finalize policy, and required module grill evidence.
 
@@ -180,7 +206,7 @@ The run must record `REPO_DELIVERY_POLICY` before dispatch:
 
 Each issue runs through `workflow-build-one` or `workflow-debug`.
 
-Each issue must create its own fresh worktree before work starts. Worktree creation must follow `setup-worktree` or the Cursor `using-git-worktrees` pattern only when it is constrained to the project policy: fetch `origin`, create a fresh branch from `origin/staging`, run inside that worktree, and emit `WORKTREE_BASELINE_GATE`. Generic worktree creation that omits `origin/staging`, reuses another issue's worktree, or works from the primary checkout does not satisfy this workflow.
+Each issue must create its own fresh worktree before work starts. Worktree creation must follow `setup-worktree` or the Cursor `using-git-worktrees` pattern only when it is constrained to the project policy: fetch `origin`, resolve `WORKFLOW_BASE_GATE`, create a fresh branch from the resolved workflow base, run inside that worktree, and emit `WORKTREE_BASELINE_GATE`. Generic worktree creation that omits base resolution, reuses another issue's worktree, or works from the primary checkout does not satisfy this workflow.
 
 ### 6.1. Stacked dependent development
 
@@ -190,7 +216,7 @@ Dependent issues may continue before the parent PR is merged only through a cont
 - The child issue creates its own fresh worktree from the parent branch, not from the primary checkout.
 - The child PR targets the parent branch, not `staging`.
 - The child handoff records:
-  `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete`
+  `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete`
 - The stack handoff records merge order and retargeting instructions after the parent lands.
 
 If any parent gate is missing, stale, or not clean, the dependent issue remains `blocked` or `needs-human`. Stacked development follows `REPO_DELIVERY_POLICY`: `human-only` stacks do not permit marking PRs ready, approving, merging, enabling auto-merge, force-pushing, rebasing, or using destructive git; `auto-merge-eligible` stacks may mark ready and enable GitHub auto-merge only after gates pass and the child PR targets the parent branch.
@@ -199,7 +225,7 @@ No issue can enter finalization until `workflow-review` emits `WORKFLOW_REVIEW_G
 
 Required gates per PR:
 
-- `WORKTREE_BASELINE_GATE` or valid `STACKED_WORKTREE_GATE`
+- `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE` or valid `STACKED_WORKTREE_GATE`
 - local verification evidence
 - `user-journey-qa` when triggered
 - `WORKFLOW_REVIEW_GATE` with `review_profile`, `independent_review: true`, and `verdict: APPROVE`

--- a/dotfiles/.claude/skills/workflow-build-one/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-build-one/SKILL.md
@@ -31,7 +31,7 @@ Take a single `ready-for-agent` issue and drive it from implementation through r
 ## Flow
 
 ```
-per-issue origin/staging worktree → preflight → triage → execute-phase → workflow-review → [conditional blocking] user-journey-qa → workflow-finalize
+per-issue workflow-base worktree → preflight → triage → execute-phase → workflow-review → [conditional blocking] user-journey-qa → workflow-finalize
 ```
 
 ## Workflow Progress Reporting
@@ -60,7 +60,7 @@ Rules:
 
 ## Per-Issue Worktree Invariant
 
-Every root issue must cut its own fresh isolated worktree from `origin/staging` before implementation starts. Stacked dependent issues may instead cut their own fresh worktree from a clean parent branch when the parent PR has complete gate evidence and the child PR targets the parent branch. This is mandatory for single-issue runs, `run-backlog` dispatches, and manual invocations.
+Every root issue must cut its own fresh isolated worktree from the resolved workflow base before implementation starts. Load `setup-worktree/references/base-branch-policy.md`, record `WORKFLOW_BASE_GATE`, and use the resolved remote ref in all worktree gates. Stacked dependent issues may instead cut their own fresh worktree from a clean parent branch when the parent PR has complete gate evidence and the child PR targets the parent branch. This is mandatory for single-issue runs, `run-backlog` dispatches, and manual invocations.
 
 Do not reuse another issue's worktree. Do not work from the primary checkout. Do not start from local `main`, local `staging`, or an already-dirty branch. If the worktree cannot be created or verified, halt before changing code.
 
@@ -72,11 +72,11 @@ Do not reuse another issue's worktree. Do not work from the primary checkout. Do
 - If issue is unclear: **auto-handoff** (exit_reason: halt, blocker: what's ambiguous and what question to answer) and halt
 - Create a fresh isolated worktree for this issue before any implementation.
   Root issue:
-  `git fetch origin --prune && git worktree add -b <issue-branch> <worktree-path> origin/staging`
+  `git fetch origin --prune && git worktree add -b <issue-branch> <worktree-path> <workflow-base-ref>`
   Stacked dependent issue:
   `git fetch origin --prune && git worktree add -b <child-branch> <child-worktree-path> <parent-branch>`
 - Run the rest of this workflow from inside that worktree. If already inside a worktree, verify it has `WORKTREE_BASELINE_GATE` or valid `STACKED_WORKTREE_GATE`; otherwise halt and recreate it.
-- Record `WORKTREE_BASELINE_GATE: origin/staging -> <issue-branch> @ <worktree-path>` or `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete` in the handoff/final summary.
+- Record `WORKFLOW_BASE_GATE` and `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <issue-branch> @ <worktree-path>` or `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete` in the handoff/final summary.
 - From inside the worktree, invoke or re-run `prompt-builder` to gather repo/code context, decision-log rationale, determine execution strategy, identify files to read, and discover verification commands. A prompt-builder output created outside the per-issue worktree is bootstrap context only; it does not satisfy repo/code context gathering.
 
 ### Step 1: Triage (quick)
@@ -87,7 +87,7 @@ Do not reuse another issue's worktree. Do not work from the primary checkout. Do
 
 ### Step 2: Execute (execute-phase)
 
-- Use the branch/worktree created from `origin/staging` or a valid stacked parent branch; do not create feature branches from local `main` or the primary checkout
+- Use the branch/worktree created from the resolved workflow base or a valid stacked parent branch; do not create feature branches from local `main` or the primary checkout
 - Implement against acceptance criteria
 - Honor relevant decision-log entries and accepted tradeoffs; do not re-open settled choices unless implementation evidence invalidates them
 - Use appropriate execution profile (normal by default, strict-tdd for bugs)
@@ -143,7 +143,7 @@ Every halt produces an auto-handoff. Every completion checks for follow-up work.
 
 Before declaring done, reporting completion, or producing a handoff, verify ALL three gate blocks exist in your output for this run:
 
-1. **`WORKTREE_BASELINE_GATE`** — confirms isolated worktree from `origin/staging`
+1. **`WORKFLOW_BASE_GATE` and `WORKTREE_BASELINE_GATE`** — confirm isolated worktree from the resolved workflow base
 2. **`WORKFLOW_REVIEW_GATE`** with `review_profile`, `independent_review: true`, and `verdict: APPROVE` — confirms `workflow-review` ran with independent evidence
 3. **`WORKFLOW_FINALIZE_GATE`** — confirms `workflow-finalize` ran to completion
 
@@ -180,7 +180,7 @@ Requires: gh, git, subagent-dispatch, project-test-runner
 Side effects: creates branch, commits, PR; may modify issue labels
 Human gates: unclear issue halts (with auto-handoff); NEEDS HUMAN review halts (with auto-handoff); user-journey QA failure/unavailability halts unless waived (with auto-handoff); CI exhaustion halts (with auto-handoff); review iteration limit halts (with auto-handoff)
 
-Runtime note: project build/test tools are required for verification and are discovered from repo files (`package.json`, `Makefile`, CI workflows, language-specific config). Per-issue worktree creation from `origin/staging` is a hard precondition, not a convenience step.
+Runtime note: project build/test tools are required for verification and are discovered from repo files (`package.json`, `Makefile`, CI workflows, language-specific config). Per-issue worktree creation from the resolved workflow base is a hard precondition, not a convenience step.
 
 ## Context
 

--- a/dotfiles/.claude/skills/workflow-debug/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-debug/SKILL.md
@@ -31,7 +31,7 @@ Drive a bug from report through diagnosis to verified fix. The cardinal rule: **
 ## Flow
 
 ```text
-root worktree from origin/staging OR valid stacked worktree from parent branch → diagnose → triage → caveman → [tdd OR execute-phase] → workflow-review → [conditional blocking] user-journey-qa → workflow-finalize
+root worktree from resolved workflow base OR valid stacked worktree from parent branch → diagnose → triage → caveman → [tdd OR execute-phase] → workflow-review → [conditional blocking] user-journey-qa → workflow-finalize
 ```
 
 ## Workflow Progress Reporting
@@ -66,13 +66,13 @@ Rules:
 - Run `git fetch origin --prune`.
 - Create a fresh isolated worktree for this issue/bug before diagnosis or implementation.
   Root bug:
-  `git worktree add -b <bugfix-branch> <worktree-path> origin/staging`.
+  `git worktree add -b <bugfix-branch> <worktree-path> <workflow-base-ref>`.
   Stacked dependent bug:
   `git worktree add -b <child-branch> <child-worktree-path> <parent-branch>`.
 - Run diagnosis, implementation, review, and finalization from inside that worktree.
 - If already inside a worktree, verify it has `WORKTREE_BASELINE_GATE` or valid `STACKED_WORKTREE_GATE`; otherwise halt and recreate it.
 - Do not reuse another issue's worktree or work from the primary checkout.
-- Record `WORKTREE_BASELINE_GATE: origin/staging -> <bugfix-branch> @ <worktree-path>` or `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete` in the diagnosis artifact and final handoff.
+- Record `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> <bugfix-branch> @ <worktree-path>` or `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> <child-branch> @ <child-worktree-path>; parent_pr: #<n>; parent_gates: complete` in the diagnosis artifact and final handoff.
 
 ### Step 1: Diagnose (diagnose)
 

--- a/dotfiles/.claude/skills/workflow-effectiveness-audit/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-effectiveness-audit/SKILL.md
@@ -79,8 +79,8 @@ For each workflow invocation, derive the expected trace from the skill:
 | `workflow-finalize` | worktree baseline evidence -> optional post-mortem -> describe-pr, including reviewer validation footer when referenced issues carry `needs-human-review`, `Human review: required`, or equivalent explicit human-review gate -> ensure draft PR -> receive-review -> watch-ci -> reconcile-issues -> verification gate -> repo-policy final action |
 | `describe-pr` | PR body -> issue disposition -> record review expectations only |
 | `watch-ci` | draft PR -> CI poll -> bounded fixes -> security review -> reviewer-comment gate -> draft handoff gate |
-| `run-backlog` | queue -> dependency/stack plan -> prompt-builder per issue with mandatory worktree/stack command -> isolated per-issue origin/staging or stacked dispatch -> monitor -> reconcile -> handoff |
-| `workflow-build-one` | per-issue origin/staging worktree -> prompt-builder/preflight -> triage -> execute-phase -> workflow-review -> optional UJ QA -> workflow-finalize |
+| `run-backlog` | queue -> dependency/stack plan -> prompt-builder per issue with mandatory base/worktree/stack command -> isolated per-issue workflow-base or stacked dispatch -> monitor -> reconcile -> handoff |
+| `workflow-build-one` | per-issue workflow-base worktree -> prompt-builder/preflight -> triage -> execute-phase -> workflow-review -> optional UJ QA -> workflow-finalize |
 | `workflow-router` | classification evidence -> ROUTE_CARD -> user confirmation or valid direct/read-only skip -> target workflow preflight -> confirmed dispatch -> ROUTER_LEARNING_NOTE when completed, halted, or corrected |
 
 Mark each required step as:
@@ -120,13 +120,13 @@ Always check for these:
 1. `workflow-review` claimed completion but no independent review evidence exists.
 2. `WORKFLOW_REVIEW_GATE` missing, incomplete, self-reported by the author, missing `review_profile`, missing `independent_review: true`, or not backed by the selected profile's required reviewer outputs.
 3. `workflow-finalize` claimed completion but no `WORKFLOW_FINALIZE_GATE` exists.
-4. Mutating issue work lacks a fresh per-issue `WORKTREE_BASELINE_GATE: origin/staging -> ...` or valid `STACKED_WORKTREE_GATE: origin/staging -> <parent-branch> -> ...` created before implementation.
+4. Mutating issue work lacks `WORKFLOW_BASE_GATE` plus a fresh per-issue `WORKTREE_BASELINE_GATE: <workflow-base-ref> -> ...` or valid `STACKED_WORKTREE_GATE: <workflow-base-ref> -> <parent-branch> -> ...` created before implementation.
 5. PR was approved, auto-merged, merged, or closed while actionable review comments were unanswered.
 6. `watch-ci` handed back a draft despite unresolved comments, missing security review, or skipped required self-review.
 7. `describe-pr` used `Closes/Fixes/Resolves` for partial work.
 8. `workflow-finalize` skipped `receive-review` before `watch-ci`.
 9. `run-backlog` dispatched raw issue bodies instead of `prompt-builder` outputs.
-9a. `prompt-builder` output omitted the mandatory per-issue `origin/staging` worktree command or `WORKTREE_BASELINE_GATE` requirement.
+9a. `prompt-builder` output omitted the mandatory `WORKFLOW_BASE_GATE`, per-issue workflow-base worktree command, or `WORKTREE_BASELINE_GATE` requirement.
 9b. Stacked dependent work ran without complete clean parent gates, without `STACKED_WORKTREE_GATE`, or with a child PR targeting `staging` instead of the parent branch.
 9c. `prompt-builder` or `run-backlog` dispatched a human-review-required issue without carrying `Human review: required` and concrete `## Reviewer validation steps` into the worker prompt.
 10. `workflow-autonomous-backlog` used `repo-audit` alone for module discovery without `improve-codebase-architecture`.

--- a/dotfiles/.claude/skills/workflow-executive-doc/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-executive-doc/SKILL.md
@@ -145,7 +145,7 @@ verify the artifact against its quality bar.
 
 ## Worktree Policy
 
-This workflow is document/research work, not code delivery. It does not cut a code worktree unless the user asks to persist edits into a repository. If repository files will be edited, first create a fresh worktree from `origin/staging` and record `WORKTREE_BASELINE_GATE` in the final summary.
+This workflow is document/research work, not code delivery. It does not cut a code worktree unless the user asks to persist edits into a repository. If repository files will be edited, first resolve `WORKFLOW_BASE_GATE`, create a fresh worktree from the resolved workflow base, and record `WORKTREE_BASELINE_GATE` in the final summary.
 
 ## Contract
 

--- a/dotfiles/.claude/skills/workflow-feature/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-feature/SKILL.md
@@ -138,7 +138,7 @@ If the user wants to immediately proceed to building, they should invoke workflo
 
 ## Worktree Policy
 
-This workflow is planning/issue creation only and does not cut a code worktree. Every child issue it produces must state that implementation workflows start from a fresh worktree cut from `origin/staging`.
+This workflow is planning/issue creation only and does not cut a code worktree. Every child issue it produces must state that implementation workflows resolve `WORKFLOW_BASE_GATE` and start from a fresh worktree cut from the resolved workflow base.
 
 ## Contract
 

--- a/dotfiles/.claude/skills/workflow-finalize/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-finalize/SKILL.md
@@ -25,7 +25,7 @@ Do not accept substitutes for this precondition. Green CI, passing tests, GitHub
 
 The precondition is satisfied only by a complete `WORKFLOW_REVIEW_GATE` block from `workflow-review` with `review_profile`, `independent_review: true`, and `verdict: APPROVE`. If the block is absent, incomplete, or self-reported by the author without an independent reviewer context, halt. Do not reconstruct it from prose.
 
-The delivery branch must also have `WORKTREE_BASELINE_GATE` evidence showing it was cut from `origin/staging`, or valid `STACKED_WORKTREE_GATE` evidence showing it was cut from a clean parent branch and targets that parent branch. If the work was done in the primary checkout, on a branch based on local `main`/`staging`, or in a stacked child that targets `staging` directly, halt and require a valid worktree.
+The delivery branch must also have `WORKFLOW_BASE_GATE` plus `WORKTREE_BASELINE_GATE` evidence showing it was cut from the resolved workflow base, or valid `STACKED_WORKTREE_GATE` evidence showing it was cut from a clean parent branch and targets that parent branch. If the work was done in the primary checkout, on a branch based on local `main`/`staging`, or in a stacked child that targets the repository integration branch directly, halt and require a valid worktree.
 
 If the change is frontend or user-facing, `user-journey-qa` must also have returned PASS or have an explicit user waiver before finalization proceeds.
 
@@ -148,7 +148,7 @@ Before declaring the PR ready for final action, run a verification gate:
    `ready-for-human` or generic `Type: HITL` as this trigger.
 6. **Check for large diffs** — run `git diff --stat origin/<base>..HEAD | tail -1` and parse the file count. If **>15 files changed** or **>500 lines changed**, flag for potential PR splitting:
    - If the changes are logically atomic (single feature, single refactor), proceed but note the size in the PR description
-   - If the changes span unrelated concerns, **halt**: identify the independent concerns, create a separate branch for each from `origin/staging`, cherry-pick or re-implement the relevant commits onto each branch, and open separate PRs before merging any of them
+   - If the changes span unrelated concerns, **halt**: identify the independent concerns, resolve `WORKFLOW_BASE_GATE`, create a separate branch for each from the resolved workflow base, cherry-pick or re-implement the relevant commits onto each branch, and open separate PRs before merging any of them
 
 ### Step 7: Long-lived PR maintenance (conditional)
 
@@ -193,7 +193,8 @@ Every valid `workflow-finalize` run must emit this block verbatim:
 
 ```markdown
 WORKFLOW_FINALIZE_GATE:
-  worktree_baseline: origin/staging -> <branch> @ <worktree-path> OR stacked: origin/staging -> <parent-branch> -> <child-branch> @ <child-worktree-path>
+  workflow_base: origin/staging|origin/<default-branch>
+  worktree_baseline: <workflow-base-ref> -> <branch> @ <worktree-path> OR stacked: <workflow-base-ref> -> <parent-branch> -> <child-branch> @ <child-worktree-path>
   workflow_review_gate: APPROVE
   post_mortem: completed|not_applicable_with_reason
   describe_pr: body_file=<docs/executions/.pr-bodies/...>; mode=plan_backed|phase_run_backed|issue_only; issues=<refs|none>; phase_evidence=matched|not_applicable|waived

--- a/dotfiles/.claude/skills/workflow-review/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-review/SKILL.md
@@ -17,7 +17,29 @@ Run an independent review sized to the change's risk, then synthesize findings i
 
 ## Gate Invariant
 
-If a workflow says `workflow-review`, run this skill before proceeding to finalize/PR/CI/merge/handoff. For code changes the review must run against a branch/worktree cut from `origin/staging` (or a valid stacked worktree). Without that baseline evidence, return `NEEDS HUMAN` rather than reviewing a local-main diff.
+If a workflow says `workflow-review`, run this skill before proceeding to finalize/PR/CI/merge/handoff. For code changes the review must run against a branch/worktree cut from the resolved workflow base recorded in `WORKFLOW_BASE_GATE` (or a valid stacked worktree). Without that baseline evidence, return `NEEDS HUMAN` rather than reviewing a local-main diff.
+
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Step 0: Prepare Context | required | pending | - |
+| Step 1: Select Review Profile | required | pending | - |
+| Step 2: Dispatch Independent Review | required | pending | - |
+| Step 3: Synthesize Findings | required | pending | - |
+| Step 4: Emit Verdict Gate | required | pending | - |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- Update each step to `completed`, `blocked`, or `failed` as evidence is gathered.
+- Do not mark required review steps as skipped. If independent context is unavailable, mark Step 2 `blocked` and emit `WORKFLOW_REVIEW_GATE.verdict: NEEDS_HUMAN`.
+- Include the final ledger in every halt, handoff, and completion response.
 
 ## Required Gate Block
 
@@ -25,7 +47,8 @@ Every valid run emits this block verbatim in the synthesis and any handoff that 
 
 ```markdown
 WORKFLOW_REVIEW_GATE:
-  worktree_baseline: origin/staging -> <branch> @ <worktree-path> OR stacked: origin/staging -> <parent> -> <child> @ <path>
+  workflow_base: origin/staging|origin/<default-branch>
+  worktree_baseline: <workflow-base-ref> -> <branch> @ <worktree-path> OR stacked: <workflow-base-ref> -> <parent> -> <child> @ <path>
   skill_loaded: true
   review_profile: fast|standard|full
   independent_review: true
@@ -67,4 +90,8 @@ Only report findings the author would agree need fixing. No style nits unless th
 
 ## Contract
 
-Consumes: diff/changeset, file contents, CONTEXT.md, ADRs. Produces: review synthesis (markdown) with independent-review evidence + verdict. Requires: git, independent-review context. Side effects: none. Human gates: `NEEDS HUMAN` halts until a human responds. If subagents are unavailable, use only a host-provided fresh independent reviewer context; otherwise halt `NEEDS HUMAN`.
+Consumes: diff/changeset, file contents, CONTEXT.md, ADRs
+Produces: review synthesis (markdown) with independent-review evidence and verdict
+Requires: git, independent-review context
+Side effects: none
+Human gates: `NEEDS HUMAN` halts until a human responds. If subagents are unavailable, use only a host-provided fresh independent reviewer context; otherwise halt `NEEDS HUMAN`.

--- a/dotfiles/.claude/skills/workflow-router/SKILL.md
+++ b/dotfiles/.claude/skills/workflow-router/SKILL.md
@@ -46,6 +46,30 @@ Independence matters more than agent count. Do not use multiple agents merely
 because a workflow says "review"; use `workflow-review`'s risk-sized
 `review_profile`.
 
+## Workflow Progress Reporting
+
+At the start of every run, display a step ledger before executing or dispatching any step.
+
+```markdown
+WORKFLOW_STEPS:
+| Step | Required? | Status | Evidence / Skip Reason |
+|------|-----------|--------|------------------------|
+| Step 0: Classify Request | required | pending | - |
+| Step 1: Select Budget | required | pending | - |
+| Step 2: Emit Route Card | required | pending | - |
+| Step 3: Confirmation Gate | conditional | pending | Required for non-direct routes |
+| Step 4: Target Preflight | conditional | pending | Runs after confirmation |
+| Step 5: Dispatch Or Halt | conditional | pending | Runs after preflight |
+| Step 6: Learning Note | conditional | pending | Required for confirmed non-trivial routes, halts, or corrections |
+```
+
+Rules:
+
+- Initialize every step as `pending`.
+- A conditional step may be `skipped` only when the route is direct/read-only and no dispatch occurs; record the reason.
+- Do not dispatch before the ledger shows route confirmation and target preflight complete or not applicable.
+- Include the final ledger in every halt, handoff, and completion response.
+
 ## Route Confirmation Gate
 
 Before dispatching any non-trivial workflow, mutating workflow, scaffold, AFK run, GitHub issue/PR action, project document generation, or delivery loop, emit a `ROUTE_CARD` and wait for the user's confirmation.
@@ -169,16 +193,16 @@ Before dispatching, check the target workflow's `Requires` field:
 
 ### Worktree Baseline Gate
 
-Before dispatching any workflow that mutates code, commits, creates a PR, or runs a delivery loop, create or require a fresh isolated worktree from `origin/staging`:
+Before dispatching any workflow that mutates code, commits, creates a PR, or runs a delivery loop, load `setup-worktree/references/base-branch-policy.md`, resolve `WORKFLOW_BASE_GATE`, and create or require a fresh isolated worktree from the resolved workflow base:
 
 ```bash
 git fetch origin --prune
-git worktree add -b <workflow-branch> <worktree-path> origin/staging
+git worktree add -b <workflow-branch> <worktree-path> <workflow-base-ref>
 ```
 
-The workflow must run inside that worktree. Do not run mutating delivery workflows from the primary checkout or from a branch based on local `main`/`staging`. If `origin/staging` is missing, halt and ask the user for the replacement base.
+The workflow must run inside that worktree. Do not run mutating delivery workflows from the primary checkout or from a branch based on local `main`/`staging`. If neither `origin/staging` nor the remote default branch can be resolved, halt and ask the user for the replacement base.
 
-Read-only workflows (`workflow-review`, `workflow-effectiveness-audit`, repo audits, document workflows) do not create the worktree themselves, but if they are reviewing or finalizing code changes they must verify the change branch/worktree was cut from `origin/staging`.
+Read-only workflows (`workflow-review`, `workflow-effectiveness-audit`, repo audits, document workflows) do not create the worktree themselves, but if they are reviewing or finalizing code changes they must verify the change branch/worktree was cut from the resolved workflow base.
 
 ## Audit Routing Rule
 


### PR DESCRIPTION
## What this PR does

Hardens the local skill and workflow suite around three failure modes found during the audit: branch-base assumptions, missing workflow progress ledgers, and drift between source skills and the Codex runtime. It adds enforceable lint hooks, a shared workflow base-branch policy, and a dry-run-first runtime sync/prune helper.

## Phases completed

Issue-only maintenance PR; no plan or phase-run artifact was used.

## User-facing changes

- Adds pre-commit coverage for skill-suite invariants and skill cross-references. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-1c6f3fa5)
- Adds a skill-suite linter for frontmatter, workflow ledgers, contracts, deprecated invocation flags, and optional runtime exposure checks. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e36082fc)
- Adds a dry-run-first Codex runtime sync helper with explicit prune preview support. [diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-9af28111)
- Skips auto-merge on draft PRs and waits for the full CI validation set before enabling auto-merge. [CI diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e978df92) [auto-merge diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-ce0c953f)

## How I implemented it

The main behavior change is a shared base-branch policy that resolves `origin/staging` when present and falls back to the remote default branch only with an explicit `WORKFLOW_BASE_GATE`. `setup-worktree`, `workflow-router`, `workflow-build-one`, `run-backlog`, `execute-prd`, `execute-phase`, `workflow-review`, and `workflow-finalize` now consume that policy instead of hard-coding `origin/staging`. [policy diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-e13202af)

The workflow skills now expose `WORKFLOW_STEPS` ledgers where missing, and downstream prompt/issue skills require `WORKFLOW_BASE_GATE` plus the appropriate worktree gate in generated execution briefs. Contract fields were normalized into separate `Consumes`, `Produces`, `Requires`, `Side effects`, and `Human gates` lines so they can be linted reliably. [router diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-5ae94cbf) [review diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-fd4e6015) [backlog diff](https://github.com/johnalexwelch/dotdev/pull/60/files#diff-4aeac68c)

## Deviations from the plan

No formal plan artifact was created. One implementation adjustment was made during the audit loop: `sync-codex-skills.sh --prune` now previews prune candidates without `--apply`, instead of requiring an apply-mode destructive operation to inspect what would be removed.

A second adjustment came from live CI evidence: the auto-merge job failed because the PR was intentionally opened as a draft. The workflows now skip auto-merge for draft PRs and retry auto-merge on `ready_for_review`.

## How to verify

- `dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills`
- `dotfiles/.claude/skills/lint-skill-refs.sh dotfiles/.claude/skills`
- `bash -n dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills/sync-codex-skills.sh`
- `shellcheck dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills/sync-codex-skills.sh`
- `dotfiles/.claude/skills/sync-codex-skills.sh --prune`
- `git diff --check`
- `pre-commit run --all-files`

Runtime note: `CHECK_CODEX_RUNTIME=1 dotfiles/.claude/skills/lint-skill-suite.sh dotfiles/.claude/skills` currently reports 40 live runtime skills that are absent from active source or marked `codex-compatible:false`. This PR exposes the mismatch and provides a non-destructive prune preview, but does not prune the user's live runtime.

## Issues

No GitHub issue was linked to this maintenance pass.

## Changelog entry

chore(skills): harden workflow gates and Codex skill sync checks

## References

- `describe_pr: body_file=docs/executions/.pr-bodies/2026-06-15-pr-60.md; mode=issue_only; issues=none; phase_evidence=not_applicable; graphify=not_available_with_reason; applied_to_pr=true`
