### PR TITLE
Add safer Codex skill prune modes

### DIFF
--- a/docs/executions/.pr-bodies/2026-06-15-pr-61.md
+++ b/docs/executions/.pr-bodies/2026-06-15-pr-61.md
@@ -1,0 +1,51 @@
+## What this PR does
+
+Adds safer prune modes to the Codex skill sync helper so runtime cleanup can be staged without deleting runtime-only skills by accident. The default `--prune` behavior remains available, while new flags allow incompatible source-backed skills to be pruned independently.
+
+## Phases completed
+
+Issue-only maintenance PR; no plan or phase-run artifact was used.
+
+## User-facing changes
+
+- Adds `--prune-incompatible-only` and `--keep-runtime-only` to `sync-codex-skills.sh`. [diff](https://github.com/johnalexwelch/dotdev/pull/61/files#diff-9af28111)
+- Adds shell tests covering full prune, incompatible-only preview, keep-runtime-only preview, and apply-mode incompatible pruning. [diff](https://github.com/johnalexwelch/dotdev/pull/61/files#diff-5790f78c)
+- Includes the new sync tests in the aggregate test runner. [diff](https://github.com/johnalexwelch/dotdev/pull/61/files#diff-57282b44)
+
+## How I implemented it
+
+The sync helper now separates prune candidates into source-backed incompatible skills and runtime-only skills. `--prune-incompatible-only` enables prune mode but skips runtime-only entries. `--prune --keep-runtime-only` narrows existing prune behavior the same way, preserving a more explicit command shape for operators who still want to start from the `--prune` flag.
+
+The tests create temporary source/runtime skill trees and exercise both dry-run and apply behavior against real files. That keeps the safety property concrete: incompatible runtime skills are removed in apply mode, while runtime-only skills remain present.
+
+## Deviations from the plan
+
+No formal plan artifact was created. This follows the post-merge runtime cleanup plan: make prune safer before applying any destructive runtime cleanup.
+
+## How to verify
+
+- `bash test/test-sync-codex-skills.sh`
+- `bash -n dotfiles/.claude/skills/sync-codex-skills.sh test/test-sync-codex-skills.sh test/run-tests.sh`
+- `shellcheck dotfiles/.claude/skills/sync-codex-skills.sh test/test-sync-codex-skills.sh test/run-tests.sh`
+- `./test/run-tests.sh`
+- `git diff --check`
+- `pre-commit run --all-files`
+
+Runtime dry-runs against the current Codex skill directory:
+
+- `dotfiles/.claude/skills/sync-codex-skills.sh --prune-incompatible-only`
+- `dotfiles/.claude/skills/sync-codex-skills.sh --prune --keep-runtime-only`
+
+Both safe modes preview only `user-journey-qa`, `brain-ops`, and `slack-update` as incompatible prune candidates, preserving runtime-only skills.
+
+## Issues
+
+No GitHub issue was linked to this maintenance pass.
+
+## Changelog entry
+
+feat(skills): add safer Codex runtime prune modes
+
+## References
+
+- `describe_pr: body_file=docs/executions/.pr-bodies/2026-06-15-pr-61.md; mode=issue_only; issues=none; phase_evidence=not_applicable; graphify=not_available_with_reason; applied_to_pr=true`

--- a/dotfiles/.claude/skills/sync-codex-skills.sh
+++ b/dotfiles/.claude/skills/sync-codex-skills.sh
@@ -7,14 +7,19 @@ source_root="${SOURCE_SKILLS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}
 runtime_root="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
 apply=0
 prune=0
+keep_runtime_only=0
+prune_incompatible_only=0
 
 usage() {
     cat <<'USAGE'
-Usage: sync-codex-skills.sh [--apply] [--prune]
+Usage: sync-codex-skills.sh [--apply] [--prune] [--keep-runtime-only] [--prune-incompatible-only]
 
 Default is dry-run. --apply copies active source skills to the Codex runtime.
 --prune includes runtime skills that are not active source skills or are
 codex-incompatible in the dry run; with --apply, those skills are removed.
+--keep-runtime-only narrows --prune so runtime-only skills are preserved.
+--prune-incompatible-only is shorthand for pruning only runtime skills whose
+source skill is marked codex-compatible:false.
 USAGE
 }
 
@@ -22,6 +27,11 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --apply) apply=1 ;;
         --prune) prune=1 ;;
+        --keep-runtime-only) keep_runtime_only=1 ;;
+        --prune-incompatible-only)
+            prune=1
+            prune_incompatible_only=1
+            ;;
         -h | --help)
             usage
             exit 0
@@ -34,6 +44,11 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
+
+if [ "$keep_runtime_only" = "1" ] && [ "$prune" != "1" ]; then
+    echo "--keep-runtime-only requires --prune" >&2
+    exit 2
+fi
 
 [ -d "$source_root" ] || {
     echo "source skills root not found: $source_root" >&2
@@ -81,14 +96,28 @@ if [ "$prune" = "1" ]; then
     while IFS= read -r -d '' runtime_file; do
         skill="${runtime_file#"$runtime_root"/}"
         skill="${skill%/SKILL.md}"
-        if [ ! -f "$source_root/$skill/SKILL.md" ] ||
-            [ "$(frontmatter_value "$source_root/$skill/SKILL.md" codex-compatible)" = "false" ]; then
-            action="would prune"
-            [ "$apply" = "1" ] && action="prune"
-            printf '%s runtime-only/incompatible: %s\n' "$action" "$skill"
-            if [ "$apply" = "1" ]; then
-                rm -rf "${runtime_root:?}/$skill"
+        source_file="$source_root/$skill/SKILL.md"
+        reason=""
+
+        if [ ! -f "$source_file" ]; then
+            if [ "$keep_runtime_only" = "1" ] || [ "$prune_incompatible_only" = "1" ]; then
+                continue
             fi
+            reason="runtime-only/incompatible"
+        elif [ "$(frontmatter_value "$source_file" codex-compatible)" = "false" ]; then
+            reason="incompatible"
+            if [ "$keep_runtime_only" != "1" ] && [ "$prune_incompatible_only" != "1" ]; then
+                reason="runtime-only/incompatible"
+            fi
+        else
+            continue
+        fi
+
+        action="would prune"
+        [ "$apply" = "1" ] && action="prune"
+        printf '%s %s: %s\n' "$action" "$reason" "$skill"
+        if [ "$apply" = "1" ]; then
+            rm -rf "${runtime_root:?}/$skill"
         fi
     done < <(find "$runtime_root" -mindepth 2 -maxdepth 2 -name SKILL.md -print0)
 fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -5,3 +5,4 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 bash "$ROOT/test/test-commit-normalize.sh"
 bash "$ROOT/test/test-tmux-dev.sh"
+bash "$ROOT/test/test-sync-codex-skills.sh"

--- a/test/test-sync-codex-skills.sh
+++ b/test/test-sync-codex-skills.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/dotfiles/.claude/skills/sync-codex-skills.sh"
+TMPDIR_BASE=$(mktemp -d)
+PASS=0
+FAIL=0
+
+cleanup() {
+    rm -rf "$TMPDIR_BASE"
+}
+trap cleanup EXIT
+
+make_skill() {
+    local root="$1"
+    local name="$2"
+    local compatible="${3:-true}"
+
+    mkdir -p "$root/$name"
+    cat >"$root/$name/SKILL.md" <<EOF
+---
+name: $name
+description: test skill
+codex-compatible: $compatible
+---
+
+# $name
+EOF
+}
+
+new_fixture() {
+    local name="$1"
+    local source="$TMPDIR_BASE/$name/source"
+    local runtime="$TMPDIR_BASE/$name/runtime"
+
+    mkdir -p "$source" "$runtime"
+    make_skill "$source" active true
+    make_skill "$source" incompatible false
+    make_skill "$runtime" active true
+    make_skill "$runtime" incompatible true
+    make_skill "$runtime" runtime-only true
+    printf '%s\t%s\n' "$source" "$runtime"
+}
+
+assert_contains() {
+    local name="$1"
+    local haystack="$2"
+    local needle="$3"
+
+    if grep -Fq "$needle" <<<"$haystack"; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name"
+        echo "    expected output to contain: $needle"
+        echo "    output was:"
+        echo "$haystack"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local name="$1"
+    local haystack="$2"
+    local needle="$3"
+
+    if grep -Fq "$needle" <<<"$haystack"; then
+        echo "  FAIL: $name"
+        echo "    expected output not to contain: $needle"
+        echo "    output was:"
+        echo "$haystack"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_path_exists() {
+    local name="$1"
+    local path="$2"
+
+    if [ -e "$path" ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name"
+        echo "    expected path to exist: $path"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_path_missing() {
+    local name="$1"
+    local path="$2"
+
+    if [ ! -e "$path" ]; then
+        echo "  PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $name"
+        echo "    expected path to be absent: $path"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Codex skill sync tests ==="
+echo ""
+
+IFS=$'\t' read -r source runtime < <(new_fixture dry_full_prune)
+output=$(SOURCE_SKILLS_DIR="$source" CODEX_SKILLS_DIR="$runtime" "$SCRIPT" --prune)
+assert_contains "full prune previews incompatible runtime skill" "$output" \
+    "would prune runtime-only/incompatible: incompatible"
+assert_contains "full prune previews runtime-only skill" "$output" \
+    "would prune runtime-only/incompatible: runtime-only"
+
+IFS=$'\t' read -r source runtime < <(new_fixture dry_incompatible_only)
+output=$(SOURCE_SKILLS_DIR="$source" CODEX_SKILLS_DIR="$runtime" "$SCRIPT" --prune-incompatible-only)
+assert_contains "incompatible-only mode previews incompatible skill" "$output" \
+    "would prune incompatible: incompatible"
+assert_not_contains "incompatible-only mode preserves runtime-only skill in preview" "$output" \
+    "runtime-only"
+
+IFS=$'\t' read -r source runtime < <(new_fixture dry_keep_runtime_only)
+output=$(SOURCE_SKILLS_DIR="$source" CODEX_SKILLS_DIR="$runtime" "$SCRIPT" --prune --keep-runtime-only)
+assert_contains "keep-runtime-only mode previews incompatible skill" "$output" \
+    "would prune incompatible: incompatible"
+assert_not_contains "keep-runtime-only mode preserves runtime-only skill in preview" "$output" \
+    "runtime-only"
+
+IFS=$'\t' read -r source runtime < <(new_fixture apply_incompatible_only)
+SOURCE_SKILLS_DIR="$source" CODEX_SKILLS_DIR="$runtime" "$SCRIPT" --apply --prune-incompatible-only >/dev/null
+assert_path_missing "apply incompatible-only removes incompatible runtime skill" "$runtime/incompatible"
+assert_path_exists "apply incompatible-only keeps runtime-only skill" "$runtime/runtime-only/SKILL.md"
+assert_path_exists "apply incompatible-only syncs active source skill" "$runtime/active/SKILL.md"
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What this PR does

Adds safer prune modes to the Codex skill sync helper so runtime cleanup can be staged without deleting runtime-only skills by accident. The default `--prune` behavior remains available, while new flags allow incompatible source-backed skills to be pruned independently.

## Phases completed

Issue-only maintenance PR; no plan or phase-run artifact was used.

## User-facing changes

- Adds `--prune-incompatible-only` and `--keep-runtime-only` to `sync-codex-skills.sh`. [diff](https://github.com/johnalexwelch/dotdev/pull/61/files#diff-9af28111)
- Adds shell tests covering full prune, incompatible-only preview, keep-runtime-only preview, and apply-mode incompatible pruning. [diff](https://github.com/johnalexwelch/dotdev/pull/61/files#diff-5790f78c)
- Includes the new sync tests in the aggregate test runner. [diff](https://github.com/johnalexwelch/dotdev/pull/61/files#diff-57282b44)

## How I implemented it

The sync helper now separates prune candidates into source-backed incompatible skills and runtime-only skills. `--prune-incompatible-only` enables prune mode but skips runtime-only entries. `--prune --keep-runtime-only` narrows existing prune behavior the same way, preserving a more explicit command shape for operators who still want to start from the `--prune` flag.

The tests create temporary source/runtime skill trees and exercise both dry-run and apply behavior against real files. That keeps the safety property concrete: incompatible runtime skills are removed in apply mode, while runtime-only skills remain present.

## Deviations from the plan

No formal plan artifact was created. This follows the post-merge runtime cleanup plan: make prune safer before applying any destructive runtime cleanup.

## How to verify

- `bash test/test-sync-codex-skills.sh`
- `bash -n dotfiles/.claude/skills/sync-codex-skills.sh test/test-sync-codex-skills.sh test/run-tests.sh`
- `shellcheck dotfiles/.claude/skills/sync-codex-skills.sh test/test-sync-codex-skills.sh test/run-tests.sh`
- `./test/run-tests.sh`
- `git diff --check`
- `pre-commit run --all-files`

Runtime dry-runs against the current Codex skill directory:

- `dotfiles/.claude/skills/sync-codex-skills.sh --prune-incompatible-only`
- `dotfiles/.claude/skills/sync-codex-skills.sh --prune --keep-runtime-only`

Both safe modes preview only `user-journey-qa`, `brain-ops`, and `slack-update` as incompatible prune candidates, preserving runtime-only skills.

## Issues

No GitHub issue was linked to this maintenance pass.

## Changelog entry

feat(skills): add safer Codex runtime prune modes

## References

- `describe_pr: body_file=docs/executions/.pr-bodies/2026-06-15-pr-61.md; mode=issue_only; issues=none; phase_evidence=not_applicable; graphify=not_available_with_reason; applied_to_pr=true`
